### PR TITLE
Integrate token-level RIND rewards into PPO training

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -17,16 +17,10 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 
 from verl import DataProto
 import torch
-from verl.utils.reward_score import qa_em, qa_em_format
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 import re
 import numpy as np
-
-def _select_rm_score_fn(data_source):
-    if data_source in ['nq', 'triviaqa', 'popqa', 'web_questions', 'hotpotqa', '2wikimultihopqa', 'musique', 'bamboogle', 'strategyqa']:
-        return qa_em_format.compute_score_em
-    else:
-        raise NotImplementedError
+from verl.utils.rind_reward import RINDCalculator, assign_rind_rewards_for_generated_text
 
 
 class RewardManager():
@@ -35,11 +29,12 @@ class RewardManager():
 
     def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
         self.tokenizer = tokenizer
-        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
+        self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
+        self.rind_calculator = RINDCalculator(model=None, tokenizer=tokenizer)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -50,49 +45,27 @@ class RewardManager():
 
         reward_tensor = torch.zeros_like(data.batch['responses'], dtype=torch.float32)
 
-        # all_scores = []
-
-        already_print_data_sources = {}
-
         for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
-
-            prompt_ids = data_item.batch['prompts']
-
-            prompt_length = prompt_ids.shape[-1]
-
-            valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
-            valid_prompt_ids = prompt_ids[-valid_prompt_length:]
-
+            data_item = data[i]
             response_ids = data_item.batch['responses']
-            valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+            valid_response_length = data_item.batch['attention_mask'][data_item.batch['prompts'].shape[-1]:].sum()
             valid_response_ids = response_ids[:valid_response_length]
-
-            # decode
-            sequences = torch.cat((valid_prompt_ids, valid_response_ids))
-            sequences_str = self.tokenizer.decode(sequences)
-
-            ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
-
-            # select rm_score
-            data_source = data_item.non_tensor_batch['data_source']
-            compute_score_fn = _select_rm_score_fn(data_source)
-
-            score = compute_score_fn(solution_str=sequences_str, ground_truth=ground_truth, 
-                                     structure_format_score=self.structure_format_score, 
-                                     final_format_score=self.final_format_score, 
-                                     retrieval_score=self.retrieval_score,
-                                     format_score=self.format_score)
-
-            reward_tensor[i, valid_response_length - 1] = score
-            # all_scores.append(score)
-
-            if data_source not in already_print_data_sources:
-                already_print_data_sources[data_source] = 0
-
-            if already_print_data_sources[data_source] < self.num_examine:
-                already_print_data_sources[data_source] += 1
-                print(sequences_str)
+            gen_out = data_item.non_tensor_batch.get('generate_outputs')
+            gen_ids = data_item.non_tensor_batch.get('generated_tokens')
+            if gen_out is not None and gen_ids is not None:
+                token_scores = assign_rind_rewards_for_generated_text(
+                    self.rind_calculator,
+                    self.tokenizer,
+                    gen_out,
+                    torch.tensor(gen_ids, dtype=torch.long),
+                    theta=1.2,
+                )
+                reward_tensor[i, :token_scores.shape[0]] = token_scores
+                if i < self.num_examine:
+                    decoded = self.tokenizer.decode(valid_response_ids)
+                    print(decoded)
+            else:
+                continue
 
         return reward_tensor
 

--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -1,0 +1,164 @@
+import torch
+import numpy as np
+import spacy
+from scipy.special import softmax
+from types import SimpleNamespace
+import re
+
+ALLOWED_POS = {'NOUN', 'ADJ', 'VERB', 'PROPN', 'NUM'}
+
+class RINDCalculator:
+    def __init__(self, model, tokenizer):
+        self.model = model
+        self.tokenizer = tokenizer
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.config = getattr(model, 'config', SimpleNamespace(model_type='')) if model is not None else SimpleNamespace(model_type='')
+        if getattr(self.config, 'model_type', '') == 'llama':
+            self.space_token = '▁'
+        else:
+            space_tokens = tokenizer.tokenize(' ')
+            self.space_token = space_tokens[0] if space_tokens else ' '
+        self.nlp = spacy.load('en_core_web_sm')
+        self.method = 'dragin'
+
+    def is_content_word(self, token_str):
+        doc = self.nlp(token_str)
+        if len(doc) == 0:
+            return 0
+        tok = doc[0]
+        if tok.is_stop or tok.text.lower() in self.nlp.Defaults.stop_words:
+            return 0
+        return 1 if tok.pos_ in ALLOWED_POS else 0
+
+    def compute_rind_for_generation(self, generation_outputs, generated_tokens_ids, solver='max'):
+        gen_tokens = self.tokenizer.convert_ids_to_tokens(generated_tokens_ids)
+        gen_len = len(gen_tokens)
+
+        scores = generation_outputs.scores
+        all_logits = torch.stack(scores, dim=1).squeeze(0).cpu().numpy()
+        entropies = []
+        for i in range(gen_len):
+            probs = softmax(all_logits[i])
+            entropy = -np.sum(probs * np.log(probs + 1e-10))
+            entropies.append(entropy)
+
+        if hasattr(generation_outputs, 'attentions') and generation_outputs.attentions is not None:
+            attentions = generation_outputs.attentions
+            last_layer_attn = attentions[-1]
+            seq_len = last_layer_attn.shape[-1]
+            if solver == 'max':
+                head_max, _ = torch.max(last_layer_attn, dim=1)
+                mean_atten = torch.mean(head_max, dim=0)
+            elif solver == 'avg':
+                head_sum = torch.sum(last_layer_attn, dim=1)
+                mean_atten = torch.mean(head_sum, dim=0)
+                for i in range(seq_len):
+                    mean_atten[i] /= (seq_len - i)
+            elif solver == 'last_token':
+                mean_atten = torch.mean(last_layer_attn[:, -1], dim=0)
+            else:
+                raise ValueError(f'Unknown solver: {solver}')
+        else:
+            input_ids = generated_tokens_ids.unsqueeze(0)
+            with torch.no_grad():
+                outputs = self.model(input_ids, output_attentions=True)
+            attentions = outputs.attentions
+            last_layer_attn = attentions[-1][0]
+            seq_len = last_layer_attn.shape[1]
+            if solver == 'max':
+                head_max, _ = torch.max(last_layer_attn, dim=0)
+                mean_atten = torch.mean(head_max, dim=0)
+            elif solver == 'avg':
+                head_sum = torch.sum(last_layer_attn, dim=0)
+                mean_atten = torch.mean(head_sum, dim=0)
+                for i in range(seq_len):
+                    mean_atten[i] /= (seq_len - i)
+            elif solver == 'last_token':
+                mean_atten = torch.mean(last_layer_attn[-1], dim=0)
+            else:
+                raise ValueError(f'Unknown solver: {solver}')
+
+        spans = []
+        for i, t in enumerate(gen_tokens):
+            if i == 0 or t.startswith(self.space_token) or generated_tokens_ids[i] == 13 or (i > 0 and gen_tokens[i-1] == '</s>'):
+                spans.append([i, i])
+            else:
+                spans[-1][1] = i
+
+        rind_list = []
+        for (start, end) in spans:
+            L = end - start + 1
+            common_prefixes = {'un', 're', 'in', 'im', 'dis', 'non', 'pre', 'mis', 'sub', 'inter', 'trans'}
+            common_suffixes = {'ing', 'ed', 'ly', 'ion', 'able', 'ness', 'ment', 'ful', 'less', 'est', 'ous', 'ive', 's', 'es'}
+            word = ''.join(gen_tokens[start:end+1]).replace(self.space_token, '')
+            punct_count = sum(1 for tok in gen_tokens[start:end+1] if not tok.isalpha() and not tok.isalnum())
+            prefix_count = 1 if any(word.lower().startswith(p) for p in common_prefixes) else 0
+            suffix_count = 1 if any(word.lower().endswith(s) for s in common_suffixes) else 0
+            L_eff = max(1, L - punct_count - prefix_count - suffix_count)
+            attn_vals = mean_atten[start:end+1].tolist()
+            attn_sum = sum(attn_vals)
+            if attn_sum > 0:
+                attn_vals = [v / attn_sum for v in attn_vals]
+            else:
+                attn_vals = [0.0] * len(attn_vals)
+            max_attn = max(attn_vals) if attn_vals else 0.0
+            if self.method == 'dragin':
+                weight_vals = entropies[start:end+1]
+            else:
+                weight_vals = [1.0] * L
+            span_ent = sum(weight_vals) / L
+            s = self.is_content_word(word)
+            rind = max_attn * span_ent * s * L_eff
+            pos_tag = self.nlp(word)[0].pos_ if len(self.nlp(word)) > 0 else ''
+            rind_list.append((word, rind, max_attn, span_ent, L_eff, pos_tag))
+        return rind_list
+
+
+def assign_rind_rewards_for_generated_text(rind_calc, tokenizer, generation_outputs, generated_tokens_ids, theta=1.2):
+    resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
+    doc = rind_calc.nlp(resp_text)
+    sentences = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+    token_scores = torch.zeros(len(generated_tokens_ids), dtype=torch.float32)
+    encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
+    offsets = encoding['offset_mapping']
+    skip_spans = []
+    for tag in ('search', 'information', 'answer'):
+        for m in re.finditer(fr'<{tag}>(.*?)</{tag}>', resp_text, re.DOTALL):
+            skip_spans.append((m.start(), m.end()))
+    skip_spans.sort()
+    merged = []
+    for s, e in skip_spans:
+        if not merged or s > merged[-1][1]:
+            merged.append([s, e])
+        else:
+            merged[-1][1] = max(merged[-1][1], e)
+    skip_spans = merged
+    for sent in sentences:
+        start_pos = resp_text.find(sent)
+        end_pos = start_pos + len(sent)
+        if (any(f'<{tag}' in sent for tag in ('search','information','answer')) or
+                any(s <= start_pos < e for s, e in skip_spans)):
+            continue
+        token_idxs = [i for i,(s,e) in enumerate(offsets) if s >= start_pos and e <= end_pos]
+        if not token_idxs:
+            continue
+        sent_tok_ids = generated_tokens_ids[token_idxs[0]: token_idxs[-1]+1]
+        mini_scores = generation_outputs.scores[token_idxs[0]: token_idxs[-1]+1]
+        mini_attns = [layer[:, token_idxs[0]:token_idxs[-1]+1, token_idxs[0]:token_idxs[-1]+1] for layer in generation_outputs.attentions]
+        mini_out = SimpleNamespace(scores=mini_scores, attentions=mini_attns)
+        rind_list = rind_calc.compute_rind_for_generation(mini_out, sent_tok_ids, solver='max')
+        M = max(r for _, r, *_ in rind_list) if rind_list else 0.0
+        tail = resp_text[end_pos:]
+        if re.match(r'\s*<search>', tail):
+            action = 'SEARCH'
+        elif re.match(r'\s*<answer>', tail):
+            action = 'ANSWER'
+        else:
+            action = 'CONTINUE_THINK'
+        if M > theta:
+            reward = 2 if action == 'SEARCH' else -2
+        else:
+            reward = 1 if action in ('CONTINUE_THINK', 'ANSWER') else -1
+        token_scores[token_idxs[-1]] = reward
+    return token_scores


### PR DESCRIPTION
## Summary
- add RINDCalculator and sentence-level reward assignment utilities
- capture logits and attention from FSDP actor after vLLM rollout for RIND
- update PPO RewardManager to distribute per-sentence rewards to tokens

## Testing
- `python -m py_compile verl/utils/rind_reward.py verl/workers/fsdp_workers.py verl/trainer/main_ppo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689638c9ec4c8331ae271c92cf97b262