### PR TITLE
Integrate RIND step rewards for PPO

### DIFF
--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import math
 import torch
 from typing import Optional, List, Union, Tuple, Unpack, Callable
 
@@ -36,10 +37,7 @@ def llama_flash_attn_forward(
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in v4.46
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    """
-        adapt from transformers 4.47.1
-        """
-    output_attentions = False
+    """adapt from transformers 4.47.1"""
 
     bsz, q_len, _ = hidden_states.size()
 
@@ -118,19 +116,39 @@ def llama_flash_attn_forward(
         key_states = key_states.to(target_dtype)
         value_states = value_states.to(target_dtype)
 
-    attn_output = _flash_attention_forward(
-        query_states,
-        key_states,
-        value_states,
-        attention_mask,
-        full_q_len,
-        position_ids=position_ids,
-        dropout=dropout_rate,
-        sliding_window=getattr(self, "sliding_window", None),
-        use_top_left_mask=self._flash_attn_uses_top_left_mask,
-        is_causal=self.is_causal,
-        **kwargs,
-    )
+    if output_attentions:
+        # manual attention computation to retrieve weights
+        q = query_states.transpose(1, 2)  # (bsz, n_head, seq_len, head_dim)
+        k = key_states.transpose(1, 2)
+        v = value_states.transpose(1, 2)
+        if self.num_key_value_groups != 1:
+            k = repeat_kv(k, self.num_key_value_groups)
+            v = repeat_kv(v, self.num_key_value_groups)
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+        if self.is_causal:
+            causal_mask = torch.triu(
+                torch.ones(q_len, q_len, device=attn_weights.device, dtype=torch.bool), 1
+            )
+            attn_weights = attn_weights.masked_fill(causal_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        if dropout_rate > 0.0:
+            attn_weights = torch.nn.functional.dropout(attn_weights, p=dropout_rate, training=self.training)
+        attn_output = torch.matmul(attn_weights, v).transpose(1, 2)
+    else:
+        attn_output = _flash_attention_forward(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            full_q_len,
+            position_ids=position_ids,
+            dropout=dropout_rate,
+            sliding_window=getattr(self, "sliding_window", None),
+            use_top_left_mask=self._flash_attn_uses_top_left_mask,
+            is_causal=self.is_causal,
+            **kwargs,
+        )
+        attn_weights = None
 
     attn_output = attn_output.reshape(bsz, full_q_len, -1, self.head_dim).contiguous()
     ########## AlltoAll for Ulysses ##########
@@ -138,8 +156,5 @@ def llama_flash_attn_forward(
         attn_output = gather_heads_scatter_seq(attn_output, seq_dim=1, head_dim=2)
     attn_output = attn_output.reshape(bsz, q_len, -1).contiguous()
     attn_output = self.o_proj(attn_output)
-
-    if not output_attentions:
-        attn_weights = None
 
     return attn_output, attn_weights, past_key_value

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -26,9 +26,21 @@ def apply_monkey_patch_to_llama():
 
 
 def apply_monkey_patch_to_qwen2():
-    from transformers.models.qwen2.modeling_qwen2 import Qwen2FlashAttention2
+    from transformers.models.qwen2 import modeling_qwen2
     from verl.models.transformers.qwen2 import qwen2_flash_attn_forward
-    Qwen2FlashAttention2.forward = qwen2_flash_attn_forward
+
+    patched = False
+    if hasattr(modeling_qwen2, "Qwen2FlashAttention2"):
+        modeling_qwen2.Qwen2FlashAttention2.forward = qwen2_flash_attn_forward
+        patched = True
+    if hasattr(modeling_qwen2, "Qwen2FlashAttention"):
+        modeling_qwen2.Qwen2FlashAttention.forward = qwen2_flash_attn_forward
+        patched = True
+    if hasattr(modeling_qwen2, "Qwen2Attention"):
+        modeling_qwen2.Qwen2Attention.forward = qwen2_flash_attn_forward
+        patched = True
+    if not patched:
+        raise AttributeError("No Qwen2 attention class found to monkey patch")
 
 
 _PATCH_NAME_TO_FUNC = {

--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -1,0 +1,142 @@
+import torch
+import numpy as np
+import spacy
+import re
+from scipy.special import softmax
+from types import SimpleNamespace
+
+ALLOWED_POS = {"NOUN", "ADJ", "VERB", "PROPN", "NUM"}
+
+class RINDCalculator:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        space_tokens = tokenizer.tokenize(" ")
+        self.space_token = space_tokens[0] if space_tokens else "▁"
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.nlp = spacy.load('en_core_web_sm')
+        self.method = "dragin"
+
+    def is_content_word(self, token_str):
+        doc = self.nlp(token_str)
+        if len(doc) == 0:
+            return 0
+        tok = doc[0]
+        if tok.is_stop or tok.text.lower() in self.nlp.Defaults.stop_words:
+            return 0
+        return 1 if tok.pos_ in ALLOWED_POS else 0
+
+    def compute_rind_for_generation(self, generation_outputs, generated_tokens_ids, solver='max'):
+        gen_tokens = self.tokenizer.convert_ids_to_tokens(generated_tokens_ids)
+        gen_len = len(generated_tokens_ids)
+        scores = generation_outputs.scores
+        all_logits = torch.stack(scores, dim=0).cpu().numpy()
+        entropies = []
+        for i in range(gen_len):
+            probs = softmax(all_logits[i])
+            entropy = -np.sum(probs * np.log(probs + 1e-10))
+            entropies.append(entropy)
+        attentions = generation_outputs.attentions
+        last_layer_attn = attentions[-1]
+        if isinstance(last_layer_attn, torch.Tensor):
+            attn_tensor = last_layer_attn
+        else:
+            attn_tensor = torch.tensor(last_layer_attn)
+        seq_len = attn_tensor.shape[1]
+        if solver == 'max':
+            head_max, _ = torch.max(attn_tensor, dim=1)
+            mean_atten = torch.mean(head_max, dim=0)
+        elif solver == 'avg':
+            head_sum = torch.sum(attn_tensor, dim=1)
+            mean_atten = torch.mean(head_sum, dim=0)
+            for i in range(seq_len):
+                mean_atten[i] /= (seq_len - i)
+        elif solver == 'last_token':
+            mean_atten = torch.mean(attn_tensor[:, -1], dim=0)
+        else:
+            raise ValueError(f"Unknown solver: {solver}")
+        spans = []
+        for i, t in enumerate(gen_tokens):
+            if i == 0 or t.startswith(self.space_token) or generated_tokens_ids[i] == 13 or (i > 0 and gen_tokens[i-1] == '</s>'):
+                spans.append([i, i])
+            else:
+                spans[-1][1] = i
+        rind_list = []
+        for (start, end) in spans:
+            L = end - start + 1
+            common_prefixes = {'un', 're', 'in', 'im', 'dis', 'non', 'pre', 'mis', 'sub', 'inter', 'trans'}
+            common_suffixes = {'ing', 'ed', 'ly', 'ion', 'able', 'ness', 'ment', 'ful', 'less', 'est', 'ous', 'ive', 's', 'es'}
+            word = ''.join(gen_tokens[start:end+1]).replace(self.space_token, '')
+            punct_count = sum(1 for tok in gen_tokens[start:end+1] if not tok.isalpha() and not tok.isalnum())
+            prefix_count = 1 if any(word.lower().startswith(p) for p in common_prefixes) else 0
+            suffix_count = 1 if any(word.lower().endswith(s) for s in common_suffixes) else 0
+            L_eff = max(1, L - punct_count - prefix_count - suffix_count)
+            attn_vals = mean_atten[start:end+1].tolist()
+            attn_sum = sum(attn_vals)
+            if attn_sum > 0:
+                attn_vals = [v / attn_sum for v in attn_vals]
+            else:
+                attn_vals = [0.0] * len(attn_vals)
+            max_attn = max(attn_vals) if attn_vals else 0.0
+            if self.method == 'dragin':
+                weight_vals = entropies[start:end+1]
+            else:
+                weight_vals = [1.0] * L
+            span_ent = sum(weight_vals) / L
+            s = self.is_content_word(word)
+            rind = max_attn * span_ent * s * L_eff
+            pos_tag = self.nlp(word)[0].pos_ if len(self.nlp(word)) > 0 else ""
+            rind_list.append((word, rind, max_attn, span_ent, L_eff, pos_tag))
+        return rind_list
+
+def assign_rind_rewards_for_generated_text(rind_calc, tokenizer, generation_outputs, generated_tokens_ids, reward_tensor_row, theta=1.2, debug=False):
+    resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
+    doc = rind_calc.nlp(resp_text)
+    sentences = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+    skip_spans = []
+    for tag in ("search", "information", "answer"):
+        for m in re.finditer(fr"<{tag}>(.*?)</{tag}>", resp_text, re.DOTALL):
+            skip_spans.append((m.start(), m.end()))
+    skip_spans.sort()
+    merged = []
+    for s, e in skip_spans:
+        if not merged or s > merged[-1][1]:
+            merged.append([s, e])
+        else:
+            merged[-1][1] = max(merged[-1][1], e)
+    skip_spans = merged
+    encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
+    offsets = encoding["offset_mapping"]
+    token_scores = torch.zeros(len(generated_tokens_ids) - 1, dtype=torch.float32)
+    for sent in sentences:
+        start_pos = resp_text.find(sent)
+        end_pos = start_pos + len(sent)
+        if any(f"<{tag}" in sent for tag in ("search", "information", "answer")) or any(s <= start_pos < e for s, e in skip_spans):
+            if debug:
+                print(f"Skip tagged sentence:\n {sent} -> reward 0")
+            continue
+        token_idxs = [i for i, (s, e) in enumerate(offsets) if s >= start_pos and e <= end_pos]
+        if not token_idxs:
+            continue
+        sent_tok_ids = generated_tokens_ids[token_idxs[0]: token_idxs[-1] + 1]
+        sent_scores = generation_outputs.scores[token_idxs[0]: token_idxs[-1] + 1]
+        sent_attn = [layer[:, token_idxs[0]: token_idxs[-1] + 1, token_idxs[0]: token_idxs[-1] + 1] for layer in generation_outputs.attentions]
+        mini_out = SimpleNamespace(scores=tuple(sent_scores), attentions=tuple(sent_attn))
+        rind_list = rind_calc.compute_rind_for_generation(mini_out, sent_tok_ids, solver='max')
+        M = max((r for _, r, *_ in rind_list), default=0.0)
+        tail = resp_text[end_pos:]
+        if re.match(r'\s*<search>', tail):
+            action = 'SEARCH'
+        elif re.match(r'\s*<answer>', tail):
+            action = 'ANSWER'
+        else:
+            action = 'CONTINUE_THINK'
+        if M > theta:
+            reward = 2 if action == 'SEARCH' else -2
+        else:
+            reward = 1 if action in ('CONTINUE_THINK', 'ANSWER') else -1
+        token_scores[token_idxs[-1]] = reward
+        if debug:
+            print(f"Sentence:\n {sent}\n  MaxRIND={M:.4f}, Action={action}, Reward={reward}")
+    reward_tensor_row[: token_scores.size(0)] = token_scores
+    return reward_tensor_row


### PR DESCRIPTION
## Summary
- capture logits and attention during rollout to support RIND reward
- add RIND calculator and reward assignment utilities
- use RIND-based token rewards in PPO RewardManager
- ensure custom Llama/Qwen2 flash attention honors `output_attentions` so reward code can access attention weights
- broaden Qwen2 monkey patch to cover additional attention classes and predefine `attn_weights`
- always apply monkey patch when removing padding and autocast RIND forward pass to bfloat16 to avoid attention errors

## Testing
- `python -m py_compile verl/utils/rind_reward.py verl/workers/fsdp_workers.py verl/models/transformers/qwen2.py verl/models/transformers/monkey_patch.py`


------
https://chatgpt.com/codex/tasks/task_e_6896eab6ada483318b27f519e759190b