### PR TITLE
Integrate RIND step rewards for PPO

### DIFF
--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import math
 import torch
 from typing import Optional, List, Union, Tuple, Unpack, Callable
 
@@ -36,10 +37,7 @@ def llama_flash_attn_forward(
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in v4.46
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    """
-        adapt from transformers 4.47.1
-        """
-    output_attentions = False
+    """adapt from transformers 4.47.1"""
 
     bsz, q_len, _ = hidden_states.size()
 
@@ -118,19 +116,39 @@ def llama_flash_attn_forward(
         key_states = key_states.to(target_dtype)
         value_states = value_states.to(target_dtype)
 
-    attn_output = _flash_attention_forward(
-        query_states,
-        key_states,
-        value_states,
-        attention_mask,
-        full_q_len,
-        position_ids=position_ids,
-        dropout=dropout_rate,
-        sliding_window=getattr(self, "sliding_window", None),
-        use_top_left_mask=self._flash_attn_uses_top_left_mask,
-        is_causal=self.is_causal,
-        **kwargs,
-    )
+    if output_attentions:
+        # manual attention computation to retrieve weights
+        q = query_states.transpose(1, 2)  # (bsz, n_head, seq_len, head_dim)
+        k = key_states.transpose(1, 2)
+        v = value_states.transpose(1, 2)
+        if self.num_key_value_groups != 1:
+            k = repeat_kv(k, self.num_key_value_groups)
+            v = repeat_kv(v, self.num_key_value_groups)
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+        if self.is_causal:
+            causal_mask = torch.triu(
+                torch.ones(q_len, q_len, device=attn_weights.device, dtype=torch.bool), 1
+            )
+            attn_weights = attn_weights.masked_fill(causal_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        if dropout_rate > 0.0:
+            attn_weights = torch.nn.functional.dropout(attn_weights, p=dropout_rate, training=self.training)
+        attn_output = torch.matmul(attn_weights, v).transpose(1, 2)
+    else:
+        attn_output = _flash_attention_forward(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            full_q_len,
+            position_ids=position_ids,
+            dropout=dropout_rate,
+            sliding_window=getattr(self, "sliding_window", None),
+            use_top_left_mask=self._flash_attn_uses_top_left_mask,
+            is_causal=self.is_causal,
+            **kwargs,
+        )
+        attn_weights = None
 
     attn_output = attn_output.reshape(bsz, full_q_len, -1, self.head_dim).contiguous()
     ########## AlltoAll for Ulysses ##########
@@ -138,8 +156,5 @@ def llama_flash_attn_forward(
         attn_output = gather_heads_scatter_seq(attn_output, seq_dim=1, head_dim=2)
     attn_output = attn_output.reshape(bsz, q_len, -1).contiguous()
     attn_output = self.o_proj(attn_output)
-
-    if not output_attentions:
-        attn_weights = None
 
     return attn_output, attn_weights, past_key_value

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -26,9 +26,21 @@ def apply_monkey_patch_to_llama():
 
 
 def apply_monkey_patch_to_qwen2():
-    from transformers.models.qwen2.modeling_qwen2 import Qwen2FlashAttention2
+    from transformers.models.qwen2 import modeling_qwen2
     from verl.models.transformers.qwen2 import qwen2_flash_attn_forward
-    Qwen2FlashAttention2.forward = qwen2_flash_attn_forward
+
+    patched = False
+    if hasattr(modeling_qwen2, "Qwen2FlashAttention2"):
+        modeling_qwen2.Qwen2FlashAttention2.forward = qwen2_flash_attn_forward
+        patched = True
+    if hasattr(modeling_qwen2, "Qwen2FlashAttention"):
+        modeling_qwen2.Qwen2FlashAttention.forward = qwen2_flash_attn_forward
+        patched = True
+    if hasattr(modeling_qwen2, "Qwen2Attention"):
+        modeling_qwen2.Qwen2Attention.forward = qwen2_flash_attn_forward
+        patched = True
+    if not patched:
+        raise AttributeError("No Qwen2 attention class found to monkey patch")
 
 
 _PATCH_NAME_TO_FUNC = {

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -17,16 +17,7 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 
 from verl import DataProto
 import torch
-from verl.utils.reward_score import qa_em, qa_em_format
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
-import re
-import numpy as np
-
-def _select_rm_score_fn(data_source):
-    if data_source in ['nq', 'triviaqa', 'popqa', 'web_questions', 'hotpotqa', '2wikimultihopqa', 'musique', 'bamboogle', 'strategyqa']:
-        return qa_em_format.compute_score_em
-    else:
-        raise NotImplementedError
 
 
 class RewardManager():
@@ -35,7 +26,7 @@ class RewardManager():
 
     def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
         self.tokenizer = tokenizer
-        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
+        self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
@@ -50,46 +41,30 @@ class RewardManager():
 
         reward_tensor = torch.zeros_like(data.batch['responses'], dtype=torch.float32)
 
-        # all_scores = []
-
         already_print_data_sources = {}
 
         for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
+            data_item = data[i]
 
             prompt_ids = data_item.batch['prompts']
-
             prompt_length = prompt_ids.shape[-1]
-
             valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch['responses']
             valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
-            valid_response_ids = response_ids[:valid_response_length]
 
-            # decode
-            sequences = torch.cat((valid_prompt_ids, valid_response_ids))
+            sequences = torch.cat((valid_prompt_ids, response_ids[:valid_response_length]))
             sequences_str = self.tokenizer.decode(sequences)
 
-            ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
+            rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            for pos, val in rewards:
+                if pos < valid_response_length:
+                    reward_tensor[i, pos] = val
 
-            # select rm_score
-            data_source = data_item.non_tensor_batch['data_source']
-            compute_score_fn = _select_rm_score_fn(data_source)
-
-            score = compute_score_fn(solution_str=sequences_str, ground_truth=ground_truth, 
-                                     structure_format_score=self.structure_format_score, 
-                                     final_format_score=self.final_format_score, 
-                                     retrieval_score=self.retrieval_score,
-                                     format_score=self.format_score)
-
-            reward_tensor[i, valid_response_length - 1] = score
-            # all_scores.append(score)
-
+            data_source = data_item.non_tensor_batch.get('data_source', 'unknown')
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0
-
             if already_print_data_sources[data_source] < self.num_examine:
                 already_print_data_sources[data_source] += 1
                 print(sequences_str)

--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -1,0 +1,170 @@
+import torch
+import numpy as np
+import spacy
+import re
+from scipy.special import softmax
+
+
+ALLOWED_POS = {"NOUN", "ADJ", "VERB", "PROPN", "NUM"}
+
+class RINDCalculator:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        space_tokens = tokenizer.tokenize(" ")
+        self.space_token = space_tokens[0] if space_tokens else "▁"
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.nlp = spacy.load('en_core_web_sm')
+        self.method = "dragin"
+
+    def is_content_word(self, token_str):
+        doc = self.nlp(token_str)
+        if len(doc) == 0:
+            return 0
+        tok = doc[0]
+        if tok.is_stop or tok.text.lower() in self.nlp.Defaults.stop_words:
+            return 0
+        return 1 if tok.pos_ in ALLOWED_POS else 0
+
+    def compute_rind_from_logits_attn(self, logits, attn_tensor, generated_tokens_ids, solver='max'):
+        """Compute RIND scores given logits and attention for a span of tokens.
+
+        Args:
+            logits: Tensor of shape [L, vocab]
+            attn_tensor: Tensor of shape [num_heads, L, L]
+            generated_tokens_ids: 1D tensor/list of token ids of length L
+        """
+        gen_tokens = self.tokenizer.convert_ids_to_tokens(generated_tokens_ids)
+        gen_len = len(generated_tokens_ids)
+        logits = logits.float().cpu()
+        attn_tensor = attn_tensor.float().cpu()
+
+        entropies = []
+        for i in range(gen_len):
+            probs = softmax(logits[i].numpy())
+            entropy = -np.sum(probs * np.log(probs + 1e-10))
+            entropies.append(entropy)
+
+        if solver == 'max':
+            head_max, _ = torch.max(attn_tensor, dim=1)
+            mean_atten = torch.mean(head_max, dim=0)
+        elif solver == 'avg':
+            head_sum = torch.sum(attn_tensor, dim=1)
+            mean_atten = torch.mean(head_sum, dim=0)
+            for i in range(gen_len):
+                mean_atten[i] /= (gen_len - i)
+        elif solver == 'last_token':
+            mean_atten = torch.mean(attn_tensor[:, -1], dim=0)
+        else:
+            raise ValueError(f"Unknown solver: {solver}")
+
+        spans = []
+        for i, t in enumerate(gen_tokens):
+            if i == 0 or t.startswith(self.space_token) or generated_tokens_ids[i] == 13 or (
+                i > 0 and gen_tokens[i - 1] == '</s>'
+            ):
+                spans.append([i, i])
+            else:
+                spans[-1][1] = i
+
+        rind_list = []
+        for (start, end) in spans:
+            L = end - start + 1
+            common_prefixes = {'un', 're', 'in', 'im', 'dis', 'non', 'pre', 'mis', 'sub', 'inter', 'trans'}
+            common_suffixes = {'ing', 'ed', 'ly', 'ion', 'able', 'ness', 'ment', 'ful', 'less', 'est', 'ous', 'ive', 's', 'es'}
+            word = ''.join(gen_tokens[start:end + 1]).replace(self.space_token, '')
+            punct_count = sum(1 for tok in gen_tokens[start:end + 1] if not tok.isalpha() and not tok.isalnum())
+            prefix_count = 1 if any(word.lower().startswith(p) for p in common_prefixes) else 0
+            suffix_count = 1 if any(word.lower().endswith(s) for s in common_suffixes) else 0
+            L_eff = max(1, L - punct_count - prefix_count - suffix_count)
+
+            attn_vals = mean_atten[start:end + 1].tolist()
+            attn_sum = sum(attn_vals)
+            if attn_sum > 0:
+                attn_vals = [v / attn_sum for v in attn_vals]
+            else:
+                attn_vals = [0.0] * len(attn_vals)
+            max_attn = max(attn_vals) if attn_vals else 0.0
+
+            if self.method == 'dragin':
+                weight_vals = entropies[start:end + 1]
+            else:
+                weight_vals = [1.0] * L
+            span_ent = sum(weight_vals) / L
+
+            s = self.is_content_word(word)
+            rind = max_attn * span_ent * s * L_eff
+            pos_tag = self.nlp(word)[0].pos_ if len(self.nlp(word)) > 0 else ""
+            rind_list.append((word, rind, max_attn, span_ent, L_eff, pos_tag))
+
+        return rind_list
+
+def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False):
+    """Return a list of (token_idx, reward) for each sentence in the sequence."""
+    resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
+    doc = rind_calc.nlp(resp_text)
+    sentences = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+
+    skip_spans = []
+    for tag in ("search", "information", "answer"):
+        for m in re.finditer(fr"<{tag}>(.*?)</{tag}>", resp_text, re.DOTALL):
+            skip_spans.append((m.start(), m.end()))
+    skip_spans.sort()
+    merged = []
+    for s, e in skip_spans:
+        if not merged or s > merged[-1][1]:
+            merged.append([s, e])
+        else:
+            merged[-1][1] = max(merged[-1][1], e)
+    skip_spans = merged
+
+    encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
+    offsets = encoding["offset_mapping"]
+    rewards = []
+    token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
+
+    for sent in sentences:
+        start_pos = resp_text.find(sent)
+        end_pos = start_pos + len(sent)
+        if any(f"<{tag}" in sent for tag in ("search", "information", "answer")) or any(s <= start_pos < e for s, e in skip_spans):
+            if debug:
+                print(f"Skip tagged sentence:\n {sent} -> reward 0")
+            continue
+
+        token_idxs = [i for i, (s, e) in enumerate(offsets) if s >= start_pos and e <= end_pos]
+        if not token_idxs:
+            continue
+        end_idx = token_idxs[-1]
+        prefix_ids = token_tensor[: end_idx + 1].unsqueeze(0)
+        attn_mask = torch.ones_like(prefix_ids)
+        with torch.no_grad():
+            with torch.autocast(model.device.type, dtype=torch.bfloat16):
+                out = model(input_ids=prefix_ids,
+                            attention_mask=attn_mask,
+                            use_cache=False,
+                            output_attentions=True)
+
+        logits = out.logits[0, token_idxs[0]: end_idx + 1].cpu()
+        attn = out.attentions[-1][0, token_idxs[0]: end_idx + 1, token_idxs[0]: end_idx + 1].cpu()
+        sent_ids = generated_tokens_ids[token_idxs[0]: end_idx + 1]
+        rind_list = rind_calc.compute_rind_from_logits_attn(logits, attn, sent_ids, solver=solver)
+        M = max((r for _, r, *_ in rind_list), default=0.0)
+
+        tail = resp_text[end_pos:]
+        if re.match(r'\s*<search>', tail):
+            action = 'SEARCH'
+        elif re.match(r'\s*<answer>', tail):
+            action = 'ANSWER'
+        else:
+            action = 'CONTINUE_THINK'
+
+        if M > theta:
+            reward = 2 if action == 'SEARCH' else -2
+        else:
+            reward = 1 if action in ('CONTINUE_THINK', 'ANSWER') else -1
+
+        rewards.append((end_idx, reward))
+        if debug:
+            print(f"Sentence:\n {sent}\n  MaxRIND={M:.4f}, Action={action}, Reward={reward}")
+
+    return rewards

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -37,6 +37,8 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.flops_counter import FlopsCounter
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+import numpy as np
+from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
 
 from codetiming import Timer
 
@@ -142,7 +144,7 @@ class ActorRolloutRefWorker(Worker):
             from verl.models.registry import check_model_support_rmpad
             check_model_support_rmpad(actor_model_config.model_type)
 
-        if use_remove_padding and self.ulysses_sequence_parallel_size > 1:
+        if use_remove_padding:
             from verl.models.transformers.monkey_patch import apply_monkey_patch
             apply_monkey_patch(actor_model_config, verbose=True)
 
@@ -350,6 +352,8 @@ class ActorRolloutRefWorker(Worker):
         if self._is_actor:
             self.flops_counter = FlopsCounter(self.actor_model_config)
 
+        self.rind_calculator = RINDCalculator(self.tokenizer)
+
         torch.cuda.empty_cache()
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -465,6 +469,22 @@ class ActorRolloutRefWorker(Worker):
                 old_log_probs = self.actor.compute_log_prob(data=output)
                 output.batch['old_log_probs'] = old_log_probs
                 output = self.ulysses_sharding_manager.postprocess_data(output)
+
+        # compute sentence-level rewards on the fly
+        responses = output.batch['responses'].cpu()
+        sentence_rewards = []
+        for b in range(responses.size(0)):
+            token_ids = responses[b]
+            rewards = compute_sentence_end_rewards(
+                self.rind_calculator,
+                self.actor_module_fsdp,
+                self.tokenizer,
+                token_ids.tolist(),
+                theta=1.2,
+            )
+            sentence_rewards.append(rewards)
+
+        output.non_tensor_batch['sentence_rewards'] = np.array(sentence_rewards, dtype=object)
 
         output = output.to('cpu')
 
@@ -608,7 +628,7 @@ class CriticWorker(Worker):
             from verl.models.registry import check_model_support_rmpad
             check_model_support_rmpad(critic_model_config.model_type)
 
-        if use_remove_padding and self.ulysses_sequence_parallel_size > 1:
+        if use_remove_padding:
             from verl.models.transformers.monkey_patch import apply_monkey_patch
             apply_monkey_patch(critic_model_config, verbose=True)
 
@@ -847,7 +867,7 @@ class RewardModelWorker(Worker):
             from verl.models.registry import check_model_support_rmpad
             check_model_support_rmpad(model_config.model_type)
 
-        if use_remove_padding and self.ulysses_sequence_parallel_size > 1:
+        if use_remove_padding:
             from verl.models.transformers.monkey_patch import apply_monkey_patch
             apply_monkey_patch(model_config, verbose=True)
 


### PR DESCRIPTION
## Summary
- stream sentence-level RIND rewards in rollout workers to avoid retaining full logits/attentions
- compute RIND scores from per-sentence logits and attention and store only sentence-end rewards
- apply returned sentence rewards directly in PPO RewardManager

## Testing
- `python -m py_compile verl/utils/rind_reward.py verl/workers/fsdp_workers.py verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_6896eab6ada483318b27f519e759190b