### PR TITLE
feat: reuse generation logits for RIND rewards

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -18,19 +18,33 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 from verl import DataProto
 import torch
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
 
 
 class RewardManager():
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
+    def __init__(
+        self,
+        tokenizer,
+        num_examine,
+        structure_format_score=0.0,
+        final_format_score=0.0,
+        retrieval_score=0.0,
+        format_score=0.0,
+        actor_module_for_reward=None,
+        debug_rind: bool = False,
+    ) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
+        self.actor_module_for_reward = actor_module_for_reward
+        self.debug_rind = debug_rind
+        self.rind_calculator = RINDCalculator(tokenizer) if actor_module_for_reward is not None else None
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -58,6 +72,18 @@ class RewardManager():
             sequences_str = self.tokenizer.decode(sequences)
 
             rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            if not rewards and self.actor_module_for_reward is not None and 'rind_gen_scores' in data_item.non_tensor_batch:
+                rind_gen_scores = data_item.non_tensor_batch['rind_gen_scores']
+                rewards = compute_sentence_end_rewards(
+                    rind_calc=self.rind_calculator,
+                    model=self.actor_module_for_reward,
+                    tokenizer=self.tokenizer,
+                    generated_tokens_ids=response_ids[:valid_response_length].tolist(),
+                    theta=1.2,
+                    solver='max',
+                    debug=self.debug_rind,
+                    rind_gen_scores=rind_gen_scores,
+                )
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_tensor[i, pos] = val

--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -92,7 +92,17 @@ class RINDCalculator:
 
         return rind_list
 
-def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False):
+def compute_sentence_end_rewards(
+    rind_calc,
+    model,
+    tokenizer,
+    generated_tokens_ids,
+    theta: float = 1.2,
+    solver: str = "max",
+    debug: bool = False,
+    rind_gen_scores=None,
+    attn_full=None,
+):
     """Return a list of (token_idx, reward) for each sentence in the sequence."""
     resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
     doc = rind_calc.nlp(resp_text)
@@ -114,30 +124,47 @@ def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_i
     encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
     offsets = encoding["offset_mapping"]
     rewards = []
-    token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
 
-    with torch.no_grad():
-        with torch.autocast(model.device.type, dtype=torch.bfloat16):
-            out = model(
-                input_ids=token_tensor.unsqueeze(0),
-                attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
-                use_cache=False,
-                output_attentions=True,
-            )
+    entropies_full = None
+    if rind_gen_scores is not None:
+        step_logits = [t.squeeze(0).float() for t in rind_gen_scores]
+        if len(step_logits) > 0:
+            logits_cached = torch.stack(step_logits, dim=0)
+            logsumexp = torch.logsumexp(logits_cached, dim=-1, keepdim=True)
+            probs = torch.exp(logits_cached - logsumexp)
+            entropies_full = (
+                logsumexp.squeeze(-1) - (probs * logits_cached).sum(dim=-1)
+            ).cpu()
 
-    logits = out.logits[0].float()
-    # compute token entropies without materializing log-probs on CPU
-    logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
-    probs = torch.exp(logits - logsumexp)
-    entropies_full = (logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)).cpu()
+    if attn_full is None or entropies_full is None:
+        if model is None:
+            raise ValueError("model must be provided when attn_full or entropies are missing")
+        token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
+        with torch.no_grad():
+            with torch.autocast(model.device.type, dtype=torch.bfloat16):
+                out = model(
+                    input_ids=token_tensor.unsqueeze(0),
+                    attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
+                    use_cache=False,
+                    output_attentions=True,
+                )
+        if entropies_full is None:
+            logits = out.logits[0].float()
+            logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
+            probs = torch.exp(logits - logsumexp)
+            entropies_full = (
+                logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)
+            ).cpu()
+        attn_full = out.attentions[-1][0].float()
+        del out
+        if 'logits' in locals():
+            del logits, logsumexp, probs
+        torch.cuda.empty_cache()
+        gc.collect()
 
-    attn_full = out.attentions[-1][0].float()
+    attn_full = attn_full.float()
     attn_full = attn_full / attn_full.sum(dim=-1, keepdim=True).clamp_min(1e-12)
     attn_full = attn_full.cpu()
-
-    del out, logits, logsumexp, probs
-    torch.cuda.empty_cache()
-    gc.collect()
 
     for sent in sentences:
         start_pos = resp_text.find(sent)


### PR DESCRIPTION
## Summary
- reuse cached generation logits to compute RIND entropies
- derive sentence-level RIND rewards from a single forward pass
- allow fallback reward computation in RewardManager when needed

## Testing
- `python -m py_compile verl/utils/rind_reward.py verl/workers/fsdp_workers.py verl/trainer/main_ppo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c592327dc83318f43b2e98847757d