### PR TITLE
Cache generation scores for RIND entropy reuse

### DIFF
--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -92,7 +92,8 @@ class RINDCalculator:
 
         return rind_list
 
-def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False):
+def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False,
+                                 rind_gen_scores=None, rind_attentions=None):
     """Return a list of (token_idx, reward) for each sentence in the sequence."""
     resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
     doc = rind_calc.nlp(resp_text)
@@ -114,30 +115,43 @@ def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_i
     encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
     offsets = encoding["offset_mapping"]
     rewards = []
-    token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
 
-    with torch.no_grad():
-        with torch.autocast(model.device.type, dtype=torch.bfloat16):
-            out = model(
-                input_ids=token_tensor.unsqueeze(0),
-                attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
-                use_cache=False,
-                output_attentions=True,
-            )
+    entropies_full = None
+    attn_full = None
+    if rind_gen_scores is not None:
+        step_logits = [t.squeeze(0).float() for t in rind_gen_scores]
+        if len(step_logits) > 0:
+            logits = torch.stack(step_logits, dim=0)
+            logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
+            probs = torch.exp(logits - logsumexp)
+            entropies_full = (logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)).cpu()
+    if rind_attentions is not None:
+        attn_full = rind_attentions.float().cpu()
 
-    logits = out.logits[0].float()
-    # compute token entropies without materializing log-probs on CPU
-    logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
-    probs = torch.exp(logits - logsumexp)
-    entropies_full = (logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)).cpu()
+    if entropies_full is None or attn_full is None:
+        assert model is not None, "model is required when cached scores or attentions are missing"
+        token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
+        with torch.no_grad():
+            with torch.autocast(model.device.type, dtype=torch.bfloat16):
+                out = model(
+                    input_ids=token_tensor.unsqueeze(0),
+                    attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
+                    use_cache=False,
+                    output_attentions=True,
+                )
+        if entropies_full is None:
+            logits = out.logits[0].float()
+            logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
+            probs = torch.exp(logits - logsumexp)
+            entropies_full = (logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)).cpu()
+        if attn_full is None:
+            attn_full = out.attentions[-1][0].float()
+        del out
+        torch.cuda.empty_cache()
+        gc.collect()
 
-    attn_full = out.attentions[-1][0].float()
     attn_full = attn_full / attn_full.sum(dim=-1, keepdim=True).clamp_min(1e-12)
     attn_full = attn_full.cpu()
-
-    del out, logits, logsumexp, probs
-    torch.cuda.empty_cache()
-    gc.collect()
 
     for sent in sentences:
         start_pos = resp_text.find(sent)


### PR DESCRIPTION
## Summary
- cache teacher-forced logits and attentions during rollout for later RIND reward computation
- compute sentence-level rewards using cached scores when available, avoiding extra forward passes
- wire reward manager to pass cached logits/attentions to the RIND calculator

## Testing
- `pytest`
- `python -m py_compile verl/workers/fsdp_workers.py verl/utils/rind_reward.py verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_689c5ea43c0c8331bb759953fc723001