### PR TITLE
Cache generation scores for RIND entropy reuse

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -18,19 +18,23 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 from verl import DataProto
 import torch
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
 
 
 class RewardManager():
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
+    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0., actor_module_for_reward=None, debug_rind=False) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
+        self.actor_module_for_reward = actor_module_for_reward
+        self.debug_rind = debug_rind
+        self.rind_calculator = RINDCalculator(tokenizer)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -57,7 +61,24 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[:valid_response_length]))
             sequences_str = self.tokenizer.decode(sequences)
 
-            rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            rewards = data_item.non_tensor_batch.get('sentence_rewards', None)
+            if rewards is None:
+                rind_ents = data_item.non_tensor_batch.get('rind_entropies', None)
+                rind_mean_attn = data_item.non_tensor_batch.get('rind_mean_attentions', None)
+                if rind_ents is not None and rind_mean_attn is not None:
+                    rewards = compute_sentence_end_rewards(
+                        rind_calc=self.rind_calculator,
+                        model=self.actor_module_for_reward,
+                        tokenizer=self.tokenizer,
+                        generated_tokens_ids=response_ids[:valid_response_length].tolist(),
+                        theta=1.2,
+                        solver='max',
+                        debug=self.debug_rind,
+                        rind_entropies=rind_ents,
+                        rind_mean_attentions=rind_mean_attn,
+                    )
+                else:
+                    rewards = []
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_tensor[i, pos] = val

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -37,9 +37,7 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.flops_counter import FlopsCounter
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
-import numpy as np
-import gc
-from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
+from verl.utils.rind_reward import RINDCalculator
 
 from codetiming import Timer
 
@@ -471,22 +469,44 @@ class ActorRolloutRefWorker(Worker):
                 output.batch['old_log_probs'] = old_log_probs
                 output = self.ulysses_sharding_manager.postprocess_data(output)
 
-        # compute sentence-level rewards on the fly
-        responses = output.batch['responses'].cpu()
-        sentence_rewards = np.empty(responses.size(0), dtype=object)
-        for b in range(responses.size(0)):
-            token_ids = responses[b]
-            rewards = compute_sentence_end_rewards(
-                self.rind_calculator,
-                self.actor_module_fsdp,
-                self.tokenizer,
-                token_ids.tolist(),
-                theta=1.2,
-            )
-            sentence_rewards[b] = rewards
-            gc.collect()
+        # === Teacher-forced forward pass to cache logits and attentions ===
+        prompts_ids = output.batch['prompts']
+        responses_ids = output.batch['responses']
+        full_input_ids = output.batch['input_ids'].cuda()
+        full_attn_mask = (full_input_ids != self.tokenizer.pad_token_id).to(full_input_ids.dtype)
 
-        output.non_tensor_batch['sentence_rewards'] = sentence_rewards
+        with torch.no_grad():
+            out = self.actor_module_fsdp(
+                input_ids=full_input_ids,
+                attention_mask=full_attn_mask,
+                use_cache=False,
+                output_attentions=True,
+            )
+
+        logits = out.logits
+        last_attn = out.attentions[-1]
+
+        entropies_list = []
+        mean_attn_list = []
+        pad_id = self.tokenizer.pad_token_id
+        for b in range(full_input_ids.size(0)):
+            prompt_len = int((prompts_ids[b] != pad_id).sum().item())
+            resp_len = int((responses_ids[b] != pad_id).sum().item())
+            st, ed = prompt_len, prompt_len + resp_len
+            resp_logits = logits[b, st:ed, :].to(torch.float32)
+            lse = torch.logsumexp(resp_logits, dim=-1)
+            probs = torch.softmax(resp_logits, dim=-1)
+            ent = (lse - (probs * resp_logits).sum(dim=-1)).to(torch.float16)
+            entropies_list.append(ent.cpu())
+
+            attn = last_attn[b, :, st:ed, st:ed]
+            attn = attn / attn.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+            head_max = attn.max(dim=-1).values
+            mean_attn = head_max.mean(dim=0).to(torch.float16)
+            mean_attn_list.append(mean_attn.cpu())
+
+        output.non_tensor_batch['rind_entropies'] = entropies_list
+        output.non_tensor_batch['rind_mean_attentions'] = mean_attn_list
 
         output = output.to('cpu')
 


### PR DESCRIPTION
## Summary
- cache token-level entropies and reduced attentions during rollout to avoid storing full logits
- compute sentence rewards from cached vectors, with GPU fallback when missing
- update reward manager to pass cached entropy/attention vectors downstream

## Testing
- `python -m py_compile verl/workers/fsdp_workers.py verl/utils/rind_reward.py verl/trainer/main_ppo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5ea43c0c8331bb759953fc723001