### PR TITLE
Cache generation scores for RIND entropy reuse

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -18,19 +18,23 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 from verl import DataProto
 import torch
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
 
 
 class RewardManager():
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
+    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0., actor_module_for_reward=None, debug_rind=False) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
+        self.actor_module_for_reward = actor_module_for_reward
+        self.debug_rind = debug_rind
+        self.rind_calculator = RINDCalculator(tokenizer)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -57,7 +61,24 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[:valid_response_length]))
             sequences_str = self.tokenizer.decode(sequences)
 
-            rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            rewards = data_item.non_tensor_batch.get('sentence_rewards', None)
+            if rewards is None:
+                rind_ents = data_item.non_tensor_batch.get('rind_entropies', None)
+                rind_mean_attn = data_item.non_tensor_batch.get('rind_mean_attentions', None)
+                if rind_ents is not None and rind_mean_attn is not None:
+                    rewards = compute_sentence_end_rewards(
+                        rind_calc=self.rind_calculator,
+                        model=self.actor_module_for_reward,
+                        tokenizer=self.tokenizer,
+                        generated_tokens_ids=response_ids[:valid_response_length].tolist(),
+                        theta=1.2,
+                        solver='max',
+                        debug=self.debug_rind,
+                        rind_entropies=rind_ents,
+                        rind_mean_attentions=rind_mean_attn,
+                    )
+                else:
+                    rewards = []
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_tensor[i, pos] = val

--- a/verl/utils/rind_reward.py
+++ b/verl/utils/rind_reward.py
@@ -29,27 +29,30 @@ class RINDCalculator:
         """Compute RIND scores given attention weights and token entropies.
 
         Args:
-            attn_tensor: Tensor of shape [num_heads, L, L]
+            attn_tensor: Tensor of shape [num_heads, L, L] or [L]
             generated_tokens_ids: 1D tensor/list of token ids of length L
             entropies: Iterable of precomputed entropy values length L
         """
         gen_tokens = self.tokenizer.convert_ids_to_tokens(generated_tokens_ids)
         gen_len = len(generated_tokens_ids)
-        attn_tensor = attn_tensor.float().cpu()
+        attn_tensor = torch.as_tensor(attn_tensor, dtype=torch.float32).cpu()
         entropies = list(entropies)
 
-        if solver == 'max':
-            head_max, _ = torch.max(attn_tensor, dim=1)
-            mean_atten = torch.mean(head_max, dim=0)
-        elif solver == 'avg':
-            head_sum = torch.sum(attn_tensor, dim=1)
-            mean_atten = torch.mean(head_sum, dim=0)
-            for i in range(gen_len):
-                mean_atten[i] /= (gen_len - i)
-        elif solver == 'last_token':
-            mean_atten = torch.mean(attn_tensor[:, -1], dim=0)
+        if attn_tensor.dim() == 1:
+            mean_atten = attn_tensor
         else:
-            raise ValueError(f"Unknown solver: {solver}")
+            if solver == 'max':
+                head_max, _ = torch.max(attn_tensor, dim=1)
+                mean_atten = torch.mean(head_max, dim=0)
+            elif solver == 'avg':
+                head_sum = torch.sum(attn_tensor, dim=1)
+                mean_atten = torch.mean(head_sum, dim=0)
+                for i in range(gen_len):
+                    mean_atten[i] /= (gen_len - i)
+            elif solver == 'last_token':
+                mean_atten = torch.mean(attn_tensor[:, -1], dim=0)
+            else:
+                raise ValueError(f"Unknown solver: {solver}")
 
         spans = []
         for i, t in enumerate(gen_tokens):
@@ -92,7 +95,8 @@ class RINDCalculator:
 
         return rind_list
 
-def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False):
+def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_ids, theta=1.2, solver='max', debug=False,
+                                 rind_entropies=None, rind_mean_attentions=None):
     """Return a list of (token_idx, reward) for each sentence in the sequence."""
     resp_text = tokenizer.decode(generated_tokens_ids, skip_special_tokens=True)
     doc = rind_calc.nlp(resp_text)
@@ -114,30 +118,37 @@ def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_i
     encoding = tokenizer(resp_text, return_offsets_mapping=True, add_special_tokens=False)
     offsets = encoding["offset_mapping"]
     rewards = []
-    token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
 
-    with torch.no_grad():
-        with torch.autocast(model.device.type, dtype=torch.bfloat16):
-            out = model(
-                input_ids=token_tensor.unsqueeze(0),
-                attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
-                use_cache=False,
-                output_attentions=True,
-            )
+    entropies_full = None
+    mean_atten_full = None
+    if rind_entropies is not None and rind_mean_attentions is not None:
+        entropies_full = torch.as_tensor(rind_entropies, dtype=torch.float32).cpu()
+        mean_atten_full = torch.as_tensor(rind_mean_attentions, dtype=torch.float32).cpu()
+    else:
+        assert model is not None, "model is required when cached entropies or attentions are missing"
+        token_tensor = torch.tensor(generated_tokens_ids, dtype=torch.long, device=model.device)
+        T = token_tensor.size(0)
+        with torch.no_grad():
+            with torch.autocast(model.device.type, dtype=torch.bfloat16):
+                out = model(
+                    input_ids=token_tensor.unsqueeze(0),
+                    attention_mask=torch.ones_like(token_tensor).unsqueeze(0),
+                    use_cache=False,
+                    output_attentions=True,
+                )
+        resp_logits = out.logits[0, :T, :].to(torch.float32)
+        lse = torch.logsumexp(resp_logits, dim=-1)
+        probs = torch.softmax(resp_logits, dim=-1)
+        entropies_full = (lse - (probs * resp_logits).sum(dim=-1)).cpu()
 
-    logits = out.logits[0].float()
-    # compute token entropies without materializing log-probs on CPU
-    logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
-    probs = torch.exp(logits - logsumexp)
-    entropies_full = (logsumexp.squeeze(-1) - (probs * logits).sum(dim=-1)).cpu()
+        attn = out.attentions[-1][0, :, :T, :T]
+        attn = attn / attn.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        head_max = attn.max(dim=2).values
+        mean_atten_full = head_max.mean(dim=0).cpu()
 
-    attn_full = out.attentions[-1][0].float()
-    attn_full = attn_full / attn_full.sum(dim=-1, keepdim=True).clamp_min(1e-12)
-    attn_full = attn_full.cpu()
-
-    del out, logits, logsumexp, probs
-    torch.cuda.empty_cache()
-    gc.collect()
+        del out
+        torch.cuda.empty_cache()
+        gc.collect()
 
     for sent in sentences:
         start_pos = resp_text.find(sent)
@@ -151,7 +162,7 @@ def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_i
         if not token_idxs:
             continue
         start_idx, end_idx = token_idxs[0], token_idxs[-1]
-        sub_attn = attn_full[:, start_idx: end_idx + 1, start_idx: end_idx + 1]
+        sub_attn = mean_atten_full[start_idx: end_idx + 1]
         sub_ents = entropies_full[start_idx: end_idx + 1].tolist()
         sent_ids = generated_tokens_ids[start_idx: end_idx + 1]
         rind_list = rind_calc.compute_rind_from_attn_entropy(sub_attn, sent_ids, sub_ents, solver=solver)
@@ -174,5 +185,5 @@ def compute_sentence_end_rewards(rind_calc, model, tokenizer, generated_tokens_i
         if debug:
             print(f"Sentence:\n {sent}\n  MaxRIND={M:.4f}, Action={action}, Reward={reward}")
 
-    del attn_full, entropies_full
+    del mean_atten_full, entropies_full
     return rewards

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -37,9 +37,7 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.flops_counter import FlopsCounter
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
-import numpy as np
-import gc
-from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
+from verl.utils.rind_reward import RINDCalculator
 
 from codetiming import Timer
 
@@ -471,22 +469,44 @@ class ActorRolloutRefWorker(Worker):
                 output.batch['old_log_probs'] = old_log_probs
                 output = self.ulysses_sharding_manager.postprocess_data(output)
 
-        # compute sentence-level rewards on the fly
-        responses = output.batch['responses'].cpu()
-        sentence_rewards = np.empty(responses.size(0), dtype=object)
-        for b in range(responses.size(0)):
-            token_ids = responses[b]
-            rewards = compute_sentence_end_rewards(
-                self.rind_calculator,
-                self.actor_module_fsdp,
-                self.tokenizer,
-                token_ids.tolist(),
-                theta=1.2,
-            )
-            sentence_rewards[b] = rewards
-            gc.collect()
+        # === Teacher-forced forward pass to cache logits and attentions ===
+        prompts_ids = output.batch['prompts']
+        responses_ids = output.batch['responses']
+        full_input_ids = output.batch['input_ids'].cuda()
+        full_attn_mask = (full_input_ids != self.tokenizer.pad_token_id).to(full_input_ids.dtype)
 
-        output.non_tensor_batch['sentence_rewards'] = sentence_rewards
+        with torch.no_grad():
+            out = self.actor_module_fsdp(
+                input_ids=full_input_ids,
+                attention_mask=full_attn_mask,
+                use_cache=False,
+                output_attentions=True,
+            )
+
+        last_attn = out.attentions[-1]
+
+        ent_list = []
+        mean_attn_list = []
+        pad_id = self.tokenizer.pad_token_id
+        for b in range(full_input_ids.size(0)):
+            prompt_len = int((prompts_ids[b] != pad_id).sum().item())
+            resp_len = int((responses_ids[b] != pad_id).sum().item())
+            st, ed = prompt_len, prompt_len + resp_len
+
+            resp_logits = out.logits[b, st:ed, :].to(torch.float32)
+            lse = torch.logsumexp(resp_logits, dim=-1)
+            probs = torch.softmax(resp_logits, dim=-1)
+            ent = lse - (probs * resp_logits).sum(dim=-1)
+            ent_list.append(ent.to(torch.float16).cpu())
+
+            attn = last_attn[b, :, st:ed, st:ed]
+            attn = attn / attn.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+            head_max = attn.max(dim=2).values
+            mean_attn = head_max.mean(dim=0)
+            mean_attn_list.append(mean_attn.to(torch.float16).cpu())
+
+        output.non_tensor_batch['rind_entropies'] = ent_list
+        output.non_tensor_batch['rind_mean_attentions'] = mean_attn_list
 
         output = output.to('cpu')
 


### PR DESCRIPTION
## Summary
- compute per-token entropies and attention summaries on GPU during rollout and cache only 1D vectors for RIND
- use cached entropy and attention vectors in reward computation, falling back to on-the-fly model forward when absent
- update reward manager to forward cached RIND statistics instead of full logits/attentions

## Testing
- `pytest`
- `python -m py_compile verl/workers/fsdp_workers.py verl/utils/rind_reward.py verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_689c5ea43c0c8331bb759953fc723001