### PR TITLE
Cache generation scores for RIND entropy reuse

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -532,7 +532,10 @@ class DataProto:
 
         non_tensor_batch = list_of_dict_to_dict_of_list(list_of_dict=[d.non_tensor_batch for d in data])
         for key, val in non_tensor_batch.items():
-            non_tensor_batch[key] = np.concatenate(val, axis=0)
+            try:
+                non_tensor_batch[key] = np.concatenate(val, axis=0)
+            except Exception:
+                non_tensor_batch[key] = np.array(val, dtype=object)
 
         return DataProto(batch=new_batch, non_tensor_batch=non_tensor_batch, meta_info=data[0].meta_info)
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -18,19 +18,23 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 from verl import DataProto
 import torch
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.utils.rind_reward import RINDCalculator, compute_sentence_end_rewards
 
 
 class RewardManager():
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0.) -> None:
+    def __init__(self, tokenizer, num_examine, structure_format_score=0., final_format_score=0., retrieval_score=0., format_score=0., actor_module_for_reward=None, debug_rind=False) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine
         self.format_score = format_score
         self.structure_format_score = structure_format_score
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
+        self.actor_module_for_reward = actor_module_for_reward
+        self.debug_rind = debug_rind
+        self.rind_calculator = RINDCalculator(tokenizer)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -57,7 +61,24 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[:valid_response_length]))
             sequences_str = self.tokenizer.decode(sequences)
 
-            rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            rewards = data_item.non_tensor_batch.get('sentence_rewards', None)
+            if rewards is None:
+                rind_ents = data_item.non_tensor_batch.get('rind_entropies', None)
+                rind_mean_attn = data_item.non_tensor_batch.get('rind_mean_attentions', None)
+                if rind_ents is not None and rind_mean_attn is not None:
+                    rewards = compute_sentence_end_rewards(
+                        rind_calc=self.rind_calculator,
+                        model=self.actor_module_for_reward,
+                        tokenizer=self.tokenizer,
+                        generated_tokens_ids=response_ids[:valid_response_length].tolist(),
+                        theta=1.2,
+                        solver='max',
+                        debug=self.debug_rind,
+                        rind_entropies=rind_ents,
+                        rind_mean_attentions=rind_mean_attn,
+                    )
+                else:
+                    rewards = []
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_tensor[i, pos] = val


### PR DESCRIPTION
## Summary
- convert per-sample RIND entropy and attention vectors to numpy object arrays and guard DataProto concatenation for ragged inputs
- run teacher-forced forward under bfloat16 autocast and store reduced vectors instead of tensors

## Testing
- `python -m py_compile verl/protocol.py verl/workers/fsdp_workers.py verl/utils/rind_reward.py verl/trainer/main_ppo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5ea43c0c8331bb759953fc723001