### PR TITLE
fix entropy computation using full context and adjust attn dtype

### DIFF
--- a/verl/models/llama/megatron/layers/parallel_attention.py
+++ b/verl/models/llama/megatron/layers/parallel_attention.py
@@ -266,7 +266,7 @@ class ParallelLlamaAttention(nn.Module):
             attn_weights = attn_weights + attention_mask
 
         # upcast attention to fp32
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
         attn_output = torch.matmul(attn_weights, value_states)
 
         if attn_output.size() != (bsz, self.num_heads_per_tp, q_len, self.head_dim):

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -130,7 +130,7 @@ def llama_flash_attn_forward(
                 torch.ones(q_len, q_len, device=attn_weights.device, dtype=torch.bool), 1
             )
             attn_weights = attn_weights.masked_fill(causal_mask, float("-inf"))
-        attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        attn_weights = torch.softmax(attn_weights, dim=-1)
         if dropout_rate > 0.0:
             attn_weights = torch.nn.functional.dropout(attn_weights, p=dropout_rate, training=self.training)
         attn_output = torch.matmul(attn_weights, v).transpose(1, 2)

--- a/verl/models/transformers/qwen2.py
+++ b/verl/models/transformers/qwen2.py
@@ -122,7 +122,7 @@ def qwen2_flash_attn_forward(
                 torch.ones(q_len, q_len, device=attn_weights.device, dtype=torch.bool), 1
             )
             attn_weights = attn_weights.masked_fill(causal_mask, float("-inf"))
-        attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        attn_weights = torch.softmax(attn_weights, dim=-1)
         if dropout_rate > 0.0:
             attn_weights = torch.nn.functional.dropout(attn_weights, p=dropout_rate, training=self.training)
         attn_output = torch.matmul(attn_weights, v).transpose(1, 2)

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -473,13 +473,16 @@ class ActorRolloutRefWorker(Worker):
 
         # compute sentence-level rewards on the fly
         responses = output.batch['responses'].cpu()
+        prompts_ids = output.batch['prompts'].cpu()
         sentence_rewards = np.empty(responses.size(0), dtype=object)
         for b in range(responses.size(0)):
             token_ids = responses[b]
+            prompt_ids = prompts_ids[b]
             rewards = compute_sentence_end_rewards(
                 self.rind_calculator,
                 self.actor_module_fsdp,
                 self.tokenizer,
+                prompt_ids.tolist(),
                 token_ids.tolist(),
                 theta=1.2,
             )


### PR DESCRIPTION
## Summary
- compute sentence entropies with a teacher-forced pass over prompt+response to align with generation distribution
- pass prompt tokens for sentence reward calculation
- keep attention softmax in model dtype to avoid fp32 memory spike

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d922f57a083318fa04b23bd579f76