### PR TITLE
fix reward alignment after truncation

### DIFF
--- a/search_r1/llm_agent/generation.py
+++ b/search_r1/llm_agent/generation.py
@@ -257,10 +257,13 @@ class LLMGenerationManager:
             # gen_output = self.actor_rollout_wg.generate_sequences(rollings)
             rollings_active = DataProto.from_dict({
                 k: v[active_mask] for k, v in rollings.batch.items()
-            })            
+            })
             gen_output = self._generate_with_gpu_padding(rollings_active)
+            meta_info = gen_output.meta_info
+            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
+            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
 
-            # map sentence rewards back to original batch positions
+            # map sentence rewards back to original batch positions after truncation
             sr = gen_output.non_tensor_batch.get('sentence_rewards', None)
             if sr is not None:
                 active_indices = torch.where(active_mask)[0].tolist()
@@ -268,6 +271,7 @@ class LLMGenerationManager:
                     print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
                 cur_lens = self.tensor_fn.create_attention_mask(
                     original_right_side['responses']).sum(dim=1).tolist()
+                added_lens = self.tensor_fn.create_attention_mask(responses_ids).sum(dim=1).tolist()
                 pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
                 for idx, r in pair_iter:
                     if not isinstance(r, (list, tuple)):
@@ -279,15 +283,15 @@ class LLMGenerationManager:
                             print(f"[WARN] skip invalid sr item: {it}")
                             continue
                         pos, val = it
-                        if pos >= 0 and isinstance(val, (int, float)) and math.isfinite(float(val)):
+                        if (
+                            0 <= pos < added_lens[idx]
+                            and isinstance(val, (int, float))
+                            and math.isfinite(float(val))
+                        ):
                             offset_r.append((pos + cur_lens[idx], float(val)))
                         else:
                             print(f"[WARN] skip invalid reward: pos={pos}, val={val}")
                     sentence_rewards[idx].extend(offset_r)
-
-            meta_info = gen_output.meta_info
-            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
-            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
 
             # Execute in environment and process observations
             next_obs, dones, valid_action, is_search = self.execute_predictions(
@@ -328,7 +332,11 @@ class LLMGenerationManager:
             })            
             gen_output = self._generate_with_gpu_padding(rollings_active)
 
-            # collect rewards for remaining active samples
+            meta_info = gen_output.meta_info
+            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
+            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
+
+            # collect rewards for remaining active samples after truncation
             sr = gen_output.non_tensor_batch.get('sentence_rewards', None)
             if sr is not None:
                 active_indices = torch.where(active_mask)[0].tolist()
@@ -336,6 +344,7 @@ class LLMGenerationManager:
                     print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
                 cur_lens = self.tensor_fn.create_attention_mask(
                     original_right_side['responses']).sum(dim=1).tolist()
+                added_lens = self.tensor_fn.create_attention_mask(responses_ids).sum(dim=1).tolist()
                 pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
                 for idx, r in pair_iter:
                     if not isinstance(r, (list, tuple)):
@@ -347,15 +356,15 @@ class LLMGenerationManager:
                             print(f"[WARN] skip invalid sr item: {it}")
                             continue
                         pos, val = it
-                        if pos >= 0 and isinstance(val, (int, float)) and math.isfinite(float(val)):
+                        if (
+                            0 <= pos < added_lens[idx]
+                            and isinstance(val, (int, float))
+                            and math.isfinite(float(val))
+                        ):
                             offset_r.append((pos + cur_lens[idx], float(val)))
                         else:
                             print(f"[WARN] skip invalid reward: pos={pos}, val={val}")
                     sentence_rewards[idx].extend(offset_r)
-
-            meta_info = gen_output.meta_info
-            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
-            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
 
             # # Execute in environment and process observations
             _, dones, valid_action, is_search = self.execute_predictions(
@@ -378,13 +387,17 @@ class LLMGenerationManager:
         meta_info['active_mask'] = active_mask.tolist()
         meta_info['valid_action_stats'] = valid_action_stats.tolist()
         meta_info['valid_search_stats'] = valid_search_stats.tolist()
-        
+
         print("ACTIVE_TRAJ_NUM:", active_num_list)
+
+        final_valid_lens = self.tensor_fn.create_attention_mask(
+            original_right_side['responses']
+        ).sum(dim=1).tolist()
 
         for i in range(batch_size):
             agg = {}
             for pos, val in sentence_rewards[i]:
-                if pos >= 0:
+                if 0 <= pos < final_valid_lens[i]:
                     agg[pos] = agg.get(pos, 0.0) + float(val)
             sentence_rewards[i] = sorted(agg.items())
 


### PR DESCRIPTION
## Summary
- align sentence rewards with truncated responses
- ignore rewards outside of kept tokens and final length

## Testing
- `pytest`
- `python -m py_compile search_r1/llm_agent/generation.py`


------
https://chatgpt.com/codex/tasks/task_e_689fa0d73a0c8331989e8158640d4161