### PR TITLE
Fix reward alignment with info mask

### DIFF
--- a/search_r1/llm_agent/generation.py
+++ b/search_r1/llm_agent/generation.py
@@ -267,7 +267,7 @@ class LLMGenerationManager:
                 if len(active_indices) != len(sr):
                     print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
                 cur_lens = self.tensor_fn.create_attention_mask(
-                    original_right_side['responses']).sum(dim=1).tolist()
+                    original_right_side['responses_with_info_mask']).sum(dim=1).tolist()
                 pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
                 for idx, r in pair_iter:
                     if not isinstance(r, (list, tuple)):
@@ -335,7 +335,7 @@ class LLMGenerationManager:
                 if len(active_indices) != len(sr):
                     print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
                 cur_lens = self.tensor_fn.create_attention_mask(
-                    original_right_side['responses']).sum(dim=1).tolist()
+                    original_right_side['responses_with_info_mask']).sum(dim=1).tolist()
                 pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
                 for idx, r in pair_iter:
                     if not isinstance(r, (list, tuple)):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -48,19 +48,32 @@ class RewardManager():
 
             prompt_ids = data_item.batch['prompts']
             prompt_length = prompt_ids.shape[-1]
-            valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
+            info_mask = data_item.batch.get('info_mask')
+
+            if info_mask is not None:
+                valid_prompt_length = int(info_mask[:prompt_length].sum().item())
+            else:
+                valid_prompt_length = int(data_item.batch['attention_mask'][:prompt_length].sum().item())
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch['responses']
-            valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+            if info_mask is not None:
+                info_mask_resp = info_mask[prompt_length:]
+                response_positions = torch.nonzero(info_mask_resp, as_tuple=False).squeeze(-1)
+                valid_response_length = response_positions.shape[0]
+            else:
+                attention_mask_resp = data_item.batch['attention_mask'][prompt_length:]
+                valid_response_length = int(attention_mask_resp.sum().item())
+                response_positions = torch.arange(valid_response_length, device=response_ids.device)
 
-            sequences = torch.cat((valid_prompt_ids, response_ids[:valid_response_length]))
+            sequences = torch.cat((valid_prompt_ids, response_ids[response_positions]))
             sequences_str = self.tokenizer.decode(sequences)
 
             rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
             for pos, val in rewards:
                 if pos < valid_response_length:
-                    reward_tensor[i, pos] = val
+                    reward_pos = int(response_positions[pos].item())
+                    reward_tensor[i, reward_pos] = val
 
             data_source = data_item.non_tensor_batch.get('data_source', 'unknown')
             if data_source not in already_print_data_sources:


### PR DESCRIPTION
## Summary
- avoid counting `<information>` tokens when offsetting sentence rewards
- map reward positions using `info_mask` so rewards land on response tokens

## Testing
- `python -m py_compile search_r1/llm_agent/generation.py verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_689fa74041848331931310b50118cf75