### PR TITLE
Filter rewards after response truncation

### DIFF
--- a/search_r1/llm_agent/generation.py
+++ b/search_r1/llm_agent/generation.py
@@ -260,16 +260,30 @@ class LLMGenerationManager:
             })            
             gen_output = self._generate_with_gpu_padding(rollings_active)
 
-            # map sentence rewards back to original batch positions
+            meta_info = gen_output.meta_info
+
+            responses_ids_active, responses_str_active = self._postprocess_responses(
+                gen_output.batch['responses']
+            )
+            added_lens = self.tensor_fn.create_attention_mask(
+                responses_ids_active
+            ).sum(dim=1).tolist()
+
+            # map sentence rewards back to original batch positions after truncation
             sr = gen_output.non_tensor_batch.get('sentence_rewards', None)
             if sr is not None:
                 active_indices = torch.where(active_mask)[0].tolist()
                 if len(active_indices) != len(sr):
-                    print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
+                    print(
+                        f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}"
+                    )
                 cur_lens = self.tensor_fn.create_attention_mask(
-                    original_right_side['responses']).sum(dim=1).tolist()
-                pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
-                for idx, r in pair_iter:
+                    original_right_side['responses_with_info_mask']
+                ).sum(dim=1).tolist()
+                pair_iter = zip(
+                    active_indices[: len(sr)], sr[: len(active_indices)], added_lens[: len(sr)]
+                )
+                for idx, r, added in pair_iter:
                     if not isinstance(r, (list, tuple)):
                         print(f"[WARN] skip invalid sr container type: {type(r)}")
                         r = []
@@ -279,15 +293,21 @@ class LLMGenerationManager:
                             print(f"[WARN] skip invalid sr item: {it}")
                             continue
                         pos, val = it
-                        if pos >= 0 and isinstance(val, (int, float)) and math.isfinite(float(val)):
+                        if (
+                            0 <= pos < added
+                            and isinstance(val, (int, float))
+                            and math.isfinite(float(val))
+                        ):
                             offset_r.append((pos + cur_lens[idx], float(val)))
                         else:
-                            print(f"[WARN] skip invalid reward: pos={pos}, val={val}")
+                            print(
+                                f"[WARN] skip invalid reward: pos={pos}, val={val}, added={added}"
+                            )
                     sentence_rewards[idx].extend(offset_r)
 
-            meta_info = gen_output.meta_info
-            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
-            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
+            responses_ids, responses_str = self.tensor_fn._example_level_pad(
+                responses_ids_active, responses_str_active, active_mask
+            )
 
             # Execute in environment and process observations
             next_obs, dones, valid_action, is_search = self.execute_predictions(
@@ -328,16 +348,29 @@ class LLMGenerationManager:
             })            
             gen_output = self._generate_with_gpu_padding(rollings_active)
 
-            # collect rewards for remaining active samples
+            meta_info = gen_output.meta_info
+            responses_ids_active, responses_str_active = self._postprocess_responses(
+                gen_output.batch['responses']
+            )
+            added_lens = self.tensor_fn.create_attention_mask(
+                responses_ids_active
+            ).sum(dim=1).tolist()
+
+            # collect rewards for remaining active samples after truncation
             sr = gen_output.non_tensor_batch.get('sentence_rewards', None)
             if sr is not None:
                 active_indices = torch.where(active_mask)[0].tolist()
                 if len(active_indices) != len(sr):
-                    print(f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}")
+                    print(
+                        f"[WARN] sentence_rewards size mismatch: active={len(active_indices)} vs sr={len(sr)}"
+                    )
                 cur_lens = self.tensor_fn.create_attention_mask(
-                    original_right_side['responses']).sum(dim=1).tolist()
-                pair_iter = zip(active_indices[:len(sr)], sr[:len(active_indices)])
-                for idx, r in pair_iter:
+                    original_right_side['responses_with_info_mask']
+                ).sum(dim=1).tolist()
+                pair_iter = zip(
+                    active_indices[: len(sr)], sr[: len(active_indices)], added_lens[: len(sr)]
+                )
+                for idx, r, added in pair_iter:
                     if not isinstance(r, (list, tuple)):
                         print(f"[WARN] skip invalid sr container type: {type(r)}")
                         r = []
@@ -347,15 +380,21 @@ class LLMGenerationManager:
                             print(f"[WARN] skip invalid sr item: {it}")
                             continue
                         pos, val = it
-                        if pos >= 0 and isinstance(val, (int, float)) and math.isfinite(float(val)):
+                        if (
+                            0 <= pos < added
+                            and isinstance(val, (int, float))
+                            and math.isfinite(float(val))
+                        ):
                             offset_r.append((pos + cur_lens[idx], float(val)))
                         else:
-                            print(f"[WARN] skip invalid reward: pos={pos}, val={val}")
+                            print(
+                                f"[WARN] skip invalid reward: pos={pos}, val={val}, added={added}"
+                            )
                     sentence_rewards[idx].extend(offset_r)
 
-            meta_info = gen_output.meta_info
-            responses_ids, responses_str = self._postprocess_responses(gen_output.batch['responses'])
-            responses_ids, responses_str = self.tensor_fn._example_level_pad(responses_ids, responses_str, active_mask)
+            responses_ids, responses_str = self.tensor_fn._example_level_pad(
+                responses_ids_active, responses_str_active, active_mask
+            )
 
             # # Execute in environment and process observations
             _, dones, valid_action, is_search = self.execute_predictions(
@@ -380,11 +419,14 @@ class LLMGenerationManager:
         meta_info['valid_search_stats'] = valid_search_stats.tolist()
         
         print("ACTIVE_TRAJ_NUM:", active_num_list)
+        final_lens = self.tensor_fn.create_attention_mask(
+            original_right_side['responses_with_info_mask']
+        ).sum(dim=1).tolist()
 
         for i in range(batch_size):
             agg = {}
             for pos, val in sentence_rewards[i]:
-                if pos >= 0:
+                if 0 <= pos < final_lens[i]:
                     agg[pos] = agg.get(pos, 0.0) + float(val)
             sentence_rewards[i] = sorted(agg.items())
 


### PR DESCRIPTION
## Summary
- adjust run_llm_loop to truncate responses before mapping sentence rewards
- ignore reward entries that fall past the kept token span and offset remaining indices only by valid response length
- sanitize final reward list against response length to prevent out-of-range indices

## Testing
- `python -m py_compile search_r1/llm_agent/generation.py verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_689fa74041848331931310b50118cf75