### PR TITLE
Fix reward index mapping to prevent spurious entries

### DIFF
--- a/search_r1/llm_agent/generation.py
+++ b/search_r1/llm_agent/generation.py
@@ -419,15 +419,24 @@ class LLMGenerationManager:
         meta_info['valid_search_stats'] = valid_search_stats.tolist()
         
         print("ACTIVE_TRAJ_NUM:", active_num_list)
-        final_lens = self.tensor_fn.create_attention_mask(
+
+        # build a map from absolute token index to the position of
+        # response tokens (excluding information blocks) so that the
+        # reward indices match the expectation of RewardManager
+        resp_masks = self.tensor_fn.create_attention_mask(
             original_right_side['responses_with_info_mask']
-        ).sum(dim=1).tolist()
+        )
 
         for i in range(batch_size):
+            valid_positions = torch.nonzero(
+                resp_masks[i], as_tuple=False
+            ).squeeze(-1).tolist()
+            pos_map = {p: idx for idx, p in enumerate(valid_positions)}
+
             agg = {}
             for pos, val in sentence_rewards[i]:
-                if 0 <= pos < final_lens[i]:
-                    agg[pos] = agg.get(pos, 0.0) + float(val)
+                if pos in pos_map:
+                    agg[pos_map[pos]] = agg.get(pos_map[pos], 0.0) + float(val)
             sentence_rewards[i] = sorted(agg.items())
 
         prev_nt = getattr(gen_batch, 'non_tensor_batch', {}) or {}


### PR DESCRIPTION
## Summary
- map sentence reward token indices to response positions
- drop rewards outside valid response tokens to align with `RewardManager`

## Testing
- `python -m py_compile search_r1/llm_agent/generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a01247c2c883319cf9f0ae5d64bb48