### PR TITLE
Fix reward index mapping and restore round-level scoring

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -15,9 +15,30 @@
 Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
 """
 
+import re
+import numpy as np
+
 from verl import DataProto
 import torch
+from verl.utils.reward_score import qa_em, qa_em_format
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+
+
+def _select_rm_score_fn(data_source):
+    if data_source in [
+        'nq',
+        'triviaqa',
+        'popqa',
+        'web_questions',
+        'hotpotqa',
+        '2wikimultihopqa',
+        'musique',
+        'bamboogle',
+        'strategyqa',
+    ]:
+        return qa_em_format.compute_score_em
+    else:
+        raise NotImplementedError
 
 
 class RewardManager():
@@ -69,6 +90,20 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[response_positions]))
             sequences_str = self.tokenizer.decode(sequences)
 
+            ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
+            data_source = data_item.non_tensor_batch.get('data_source', 'unknown')
+            compute_score_fn = _select_rm_score_fn(data_source)
+            score = compute_score_fn(
+                solution_str=sequences_str,
+                ground_truth=ground_truth,
+                structure_format_score=self.structure_format_score,
+                final_format_score=self.final_format_score,
+                retrieval_score=self.retrieval_score,
+                format_score=self.format_score,
+            )
+            last_pos = int(response_positions[valid_response_length - 1].item())
+            reward_tensor[i, last_pos] += score
+
             rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
             for pos, val in rewards:
                 if pos < valid_response_length:
@@ -83,7 +118,6 @@ class RewardManager():
                         f"句末token: {end_token_str}, 句末token索引: {reward_pos}, 句子片段: {snippet_str}，句末奖励：{val}"
                     )
 
-            data_source = data_item.non_tensor_batch.get('data_source', 'unknown')
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0
             if already_print_data_sources[data_source] < self.num_examine:


### PR DESCRIPTION
## Summary
- map sentence reward token indices to response positions
- drop rewards outside valid response tokens to align with `RewardManager`
- avoid decode/encode drift when truncating responses so reward indices are preserved
- cache search/answer token IDs to avoid repeated encoding
- add episode-level reward accumulation in `RewardManager` for PPO training

## Testing
- `python -m py_compile search_r1/llm_agent/generation.py`
- `python -m py_compile verl/trainer/main_ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_68a01247c2c883319cf9f0ae5d64bb48