### PR TITLE
feat: add episode reward scaling

### DIFF
--- a/scripts/nq_hotpotqa/v0.6/train_grpo_format.sh
+++ b/scripts/nq_hotpotqa/v0.6/train_grpo_format.sh
@@ -77,6 +77,7 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo_sent_rind \
     reward_model.final_format_score=0.1 \
     reward_model.retrieval_score=0 \
     max_turns=4 \
+    reward_model.lambda_episode=1 \
     retriever.url="http://127.0.0.1:8000/retrieve" \
     retriever.topk=3 \
     2>&1 | tee $EXPERIMENT_NAME.log

--- a/scripts/nq_hotpotqa/v0.6/train_ppo_format.sh
+++ b/scripts/nq_hotpotqa/v0.6/train_ppo_format.sh
@@ -104,6 +104,7 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo_sent_rind \
     reward_model.final_format_score=0.1 \
     reward_model.retrieval_score=0 \
     max_turns=4 \
+    reward_model.lambda_episode=1 \
     retriever.url="http://127.0.0.1:8000/retrieve" \
     retriever.topk=3 \
     2>&1 | tee $EXPERIMENT_NAME.log

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -144,6 +144,7 @@ reward_model:
   retrieval_score: 0
   structure_format_score: 0.2
   final_format_score: 0.1
+  lambda_episode: 1.0
   lambda_task: 2.0
   lambda_search_num: 0.2
   lambda_repeat_search_num: 0.4


### PR DESCRIPTION
## Summary
- nest `lambda_episode` under `reward_model` config and default to 1.0
- propagate `reward_model.lambda_episode` through training scripts and `RewardManager` initialization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b161c3e83083319b959cf245c2188c