### PR TITLE
Propagate rind_threshold to rollout worker

### DIFF
--- a/scripts/nq_hotpotqa/v0.6/train_grpo_format.sh
+++ b/scripts/nq_hotpotqa/v0.6/train_grpo_format.sh
@@ -77,6 +77,7 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo_sent_rind \
     reward_model.final_format_score=0.1 \
     reward_model.retrieval_score=0 \
     reward_model.lambda_episode=1 \
+    reward_model.rind_threshold=1.2 \
     max_turns=4 \
     retriever.url="http://127.0.0.1:8000/retrieve" \
     retriever.topk=3 \

--- a/scripts/nq_hotpotqa/v0.6/train_ppo_format.sh
+++ b/scripts/nq_hotpotqa/v0.6/train_ppo_format.sh
@@ -104,6 +104,7 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo_sent_rind \
     reward_model.final_format_score=0.1 \
     reward_model.retrieval_score=0 \
     reward_model.lambda_episode=1 \
+    reward_model.rind_threshold=1.2 \
     max_turns=4 \
     retriever.url="http://127.0.0.1:8000/retrieve" \
     retriever.topk=3 \

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -148,6 +148,7 @@ reward_model:
   lambda_search_num: 0.2
   lambda_repeat_search_num: 0.4
   lambda_episode: 1.0
+  rind_threshold: 1.2
   model_path: "/home/jovyan/work_vol90/RL+RAG/Search-R1-main/models/qwen2.5-7b-instruct-1m"
 
 retriever:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -452,6 +452,7 @@ class RayPPOTrainer(object):
             no_think_rl=self.config.algorithm.no_think_rl,
             search_url = self.config.retriever.url,
             topk = self.config.retriever.topk,
+            rind_threshold=self.config.reward_model.rind_threshold,
         )
 
         # Agent config preparation
@@ -481,7 +482,9 @@ class RayPPOTrainer(object):
 
                 # pad to be divisible by dp_size
                 test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.actor_rollout_wg.world_size)
-                test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
+                test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(
+                    test_gen_batch_padded, theta=self.config.reward_model.rind_threshold
+                )
                 # unpad
                 test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size)
                 print('validation generation end')
@@ -683,6 +686,7 @@ class RayPPOTrainer(object):
             no_think_rl=self.config.algorithm.no_think_rl,
             search_url = self.config.retriever.url,
             topk = self.config.retriever.topk,
+            rind_threshold=self.config.reward_model.rind_threshold,
         )
 
         generation_manager = LLMGenerationManager(
@@ -709,7 +713,9 @@ class RayPPOTrainer(object):
 
                 with _timer('step', timing_raw):
                     if not self.config.do_search:
-                        gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+                        gen_batch_output = self.actor_rollout_wg.generate_sequences(
+                            gen_batch, theta=self.config.reward_model.rind_threshold
+                        )
 
                         batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
                                                                 dtype=object)

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -434,7 +434,7 @@ class ActorRolloutRefWorker(Worker):
         return output
         
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def generate_sequences(self, prompts: DataProto):
+    def generate_sequences(self, prompts: DataProto, theta: float = 1.2):
         prompts = prompts.to('cuda')
         # set to False if it is validation
         recompute_log_prob = prompts.meta_info.get('recompute_log_prob', True)
@@ -484,7 +484,7 @@ class ActorRolloutRefWorker(Worker):
                 self.tokenizer,
                 prompt_ids.tolist(),
                 token_ids.tolist(),
-                theta=1.2,
+                theta=theta,
             )
             sentence_rewards[b] = rewards
             gc.collect()

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -350,7 +350,7 @@ class ActorRolloutRefWorker(MegatronWorker):
     #     return output
 
     @register(dispatch_mode=Dispatch.MEGATRON_PP_AS_DP_PROTO)
-    def generate_sequences(self, prompts: DataProto):
+    def generate_sequences(self, prompts: DataProto, theta: float = 1.2):
         assert self._is_rollout
 
         prompts.batch = prompts.batch.cuda()


### PR DESCRIPTION
## Summary
- extend generation config with `rind_threshold`
- pass threshold through generation and trainer to rollout worker instead of reading missing config
- allow FSDP and Megatron rollout workers to accept external `theta` parameter

## Testing
- `python -m py_compile search_r1/llm_agent/generation.py verl/trainer/ppo/ray_trainer.py verl/workers/fsdp_workers.py verl/workers/megatron_workers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b171908e54833194d1c43158bd0945