### PR TITLE
feat: add sentence-level confusion metrics

### DIFF
--- a/verl/trainer/main_ppo_sent_rind.py
+++ b/verl/trainer/main_ppo_sent_rind.py
@@ -19,8 +19,9 @@ from verl import DataProto
 import torch
 from verl.utils.reward_score import qa_em, qa_em_format
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
-import re
 import numpy as np
+import spacy
+from verl.utils.reward_score.rind_reward import TAG_BOUNDARY_RE, CLOSE_TAG_RE, LEADING_CLOSE_RE
 
 
 def _select_rm_score_fn(data_source):
@@ -42,6 +43,46 @@ class RewardManager():
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
         self.lambda_episode = lambda_episode
+        self.nlp = spacy.load("en_core_web_sm", disable=["ner"])
+
+    def _count_sentences(self, text: str) -> int:
+        doc = self.nlp(text)
+        raw_sents = [span.text for span in doc.sents if span.text.strip()]
+        sentences = []
+        for sent in raw_sents:
+            parts = []
+            cur = 0
+            has_match = False
+            for m in TAG_BOUNDARY_RE.finditer(sent):
+                has_match = True
+                if m.start() > cur:
+                    parts.append(sent[cur:m.start()])
+                parts.append(m.group(0))
+                cur = m.end()
+            if cur < len(sent):
+                parts.append(sent[cur:])
+            if not has_match:
+                m = LEADING_CLOSE_RE.match(sent)
+                if m:
+                    close_part = sent[:m.end()]
+                    if sentences:
+                        sentences[-1] += close_part
+                    else:
+                        sentences.append(close_part)
+                    if m.end() < len(sent):
+                        sentences.append(sent[m.end():])
+                    continue
+            for seg in parts:
+                if not seg.strip():
+                    continue
+                if CLOSE_TAG_RE.fullmatch(seg):
+                    if sentences:
+                        sentences[-1] += seg
+                    else:
+                        sentences.append(seg)
+                else:
+                    sentences.append(seg)
+        return len(sentences)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -54,6 +95,11 @@ class RewardManager():
 
         already_print_data_sources = {}
         all_scores = []
+        last_step_vals = []
+
+        # containers for confusion matrix statistics
+        tp_list, fp_list, tn_list, fn_list = [], [], [], []
+        decision_counts, sentence_counts = [], []
 
         for i in range(len(data)):
             data_item = data[i]
@@ -81,17 +127,37 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[response_positions]))
             sequences_str = self.tokenizer.decode(sequences)
 
+            # decode response only for sentence counting
+            response_str = self.tokenizer.decode(response_ids[response_positions])
+            total_sents = self._count_sentences(response_str)
+
             rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            tp = fp = tn = fn = 0
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_pos = int(response_positions[pos].item())
                     reward_tensor[i, reward_pos] = val
+                    if val == 2:
+                        tp += 1
+                    elif val == -2:
+                        fn += 1
+                    elif val == -1:
+                        fp += 1
+                    elif val == 1:
+                        tn += 1
                     #end_token_id = response_ids[reward_pos].item()
                     #end_token_str = self.tokenizer.decode([end_token_id])
                     #start_slice = max(0, pos - 20)
                     #snippet_ids = response_ids[response_positions[start_slice:pos + 1]].tolist()
                     #snippet_str = self.tokenizer.decode(snippet_ids)
                     #print( f"句末token: {end_token_str}, 句末token索引: {reward_pos}, 句子片段: {snippet_str}，句末奖励：{val}" )
+
+            tp_list.append(tp)
+            fp_list.append(fp)
+            tn_list.append(tn)
+            fn_list.append(fn)
+            decision_counts.append(tp + fp + tn + fn)
+            sentence_counts.append(total_sents)
 
             data_source = data_item.non_tensor_batch['data_source']
             compute_score_fn = _select_rm_score_fn(data_source)
@@ -106,8 +172,10 @@ class RewardManager():
             )
             if valid_response_length > 0:
                 last_pos = int(response_positions[valid_response_length - 1].item())
+                last_step_val = float(reward_tensor[i, last_pos].item())
                 reward_tensor[i, last_pos] = reward_tensor[i, last_pos] + self.lambda_episode * score
                 all_scores.append(score)
+                last_step_vals.append(last_step_val)
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0
@@ -128,18 +196,53 @@ class RewardManager():
         else:
             resp_mask = data.batch['attention_mask'][:, prompt_len:]
         resp_mask = resp_mask.to(reward_tensor.device)
-        valid_rewards = reward_tensor[resp_mask.bool()]
+        N_total = int(resp_mask.sum().item())
 
-        if valid_rewards.numel() > 0:
-            vr = valid_rewards.cpu().numpy()
-            step_mean = vr.mean()
-            step_std = vr.std()
-            step_min = vr.min()
-            step_max = vr.max()
-            pos_rate = (vr > 0).mean()
-            neg_rate = (vr < 0).mean()
+        tp = int(np.sum(tp_list))
+        fp = int(np.sum(fp_list))
+        tn = int(np.sum(tn_list))
+        fn = int(np.sum(fn_list))
+
+        S_dec = 2 * tp + tn - fp - 2 * fn
+        SS_dec = 4 * (tp + fn) + (tn + fp)
+
+        s_list = np.array([self.lambda_episode * s for s in all_scores], dtype=np.float64)
+        v_last = np.array(last_step_vals, dtype=np.float64)
+        S_ep = float(np.sum(s_list))
+        SS_ep = float(np.sum(s_list ** 2))
+        Cross = float(np.sum(2.0 * v_last * s_list))
+
+        S_total = float(S_dec + S_ep)
+        SS_total = float(SS_dec + SS_ep + Cross)
+
+        if N_total > 0:
+            step_mean = S_total / N_total
+            step_var = max(0.0, SS_total / N_total - step_mean * step_mean)
+            step_std = float(np.sqrt(step_var))
+
+            pos_dec = tp + tn
+            neg_dec = fp + fn
+            for v, s in zip(v_last, s_list):
+                if v > 0:
+                    pos_dec -= 1
+                elif v < 0:
+                    neg_dec -= 1
+                vs = v + s
+                if vs > 0:
+                    pos_dec += 1
+                elif vs < 0:
+                    neg_dec += 1
+            pos_rate = pos_dec / N_total
+            neg_rate = neg_dec / N_total
         else:
-            step_mean = step_std = step_min = step_max = pos_rate = neg_rate = 0.0
+            step_mean = step_std = pos_rate = neg_rate = 0.0
+
+        valid_vals = reward_tensor[resp_mask.bool()]
+        if valid_vals.numel() > 0:
+            step_min = float(valid_vals.min().item())
+            step_max = float(valid_vals.max().item())
+        else:
+            step_min = step_max = 0.0
 
         print(
             f"[DEBUG][Step] step_reward/mean: {step_mean:.4f}, /std: {step_std:.4f}, /min: {step_min:.4f}, "
@@ -167,6 +270,69 @@ class RewardManager():
         print(
             f"[DEBUG][Step] sample/return_mean: {return_mean:.4f}, /std: {return_std:.4f}, /min: {return_min:.4f}, "
             f"/max: {return_max:.4f}, /nonzero_steps_mean: {nz_steps_mean:.4f}, /len_mean: {len_mean:.4f}"
+        )
+
+        # === Confusion matrix based metrics ===
+        tp_arr = np.array(tp_list)
+        fp_arr = np.array(fp_list)
+        tn_arr = np.array(tn_list)
+        fn_arr = np.array(fn_list)
+        decision_arr = np.array(decision_counts)
+        sent_arr = np.array(sentence_counts)
+
+        def safe_div(n, d):
+            return float(n) / float(d) if d else 0.0
+
+        # micro aggregation
+        m_tp, m_fp, m_tn, m_fn = tp, fp, tn, fn
+        m_decision = decision_arr.sum()
+        m_sent = sent_arr.sum()
+        micro_precision = safe_div(m_tp, m_tp + m_fp)
+        micro_recall = safe_div(m_tp, m_tp + m_fn)
+        micro_f1 = safe_div(2 * micro_precision * micro_recall, micro_precision + micro_recall)
+
+        print(
+            "[DEBUG][Confusion][Micro-Dec] "
+            f"TP%:{safe_div(m_tp, m_decision):.4f}, FN%:{safe_div(m_fn, m_decision):.4f}, "
+            f"FP%:{safe_div(m_fp, m_decision):.4f}, TN%:{safe_div(m_tn, m_decision):.4f}, "
+            f"Precision:{micro_precision:.4f}, Recall:{micro_recall:.4f}, F1:{micro_f1:.4f}"
+        )
+        print(
+            "[DEBUG][Confusion][Micro-All] "
+            f"TP%:{safe_div(m_tp, m_sent):.4f}, FN%:{safe_div(m_fn, m_sent):.4f}, "
+            f"FP%:{safe_div(m_fp, m_sent):.4f}, TN%:{safe_div(m_tn, m_sent):.4f}, "
+            f"Precision:{micro_precision:.4f}, Recall:{micro_recall:.4f}, F1:{micro_f1:.4f}, "
+            f"DecisionCoverage:{safe_div(m_decision, m_sent):.4f}"
+        )
+
+        # macro aggregation
+        macro_tp_dec = np.mean([safe_div(tp, d) for tp, d in zip(tp_arr, decision_arr)])
+        macro_fn_dec = np.mean([safe_div(fn, d) for fn, d in zip(fn_arr, decision_arr)])
+        macro_fp_dec = np.mean([safe_div(fp, d) for fp, d in zip(fp_arr, decision_arr)])
+        macro_tn_dec = np.mean([safe_div(tn, d) for tn, d in zip(tn_arr, decision_arr)])
+        macro_precision = np.mean([safe_div(tp, tp + fp) for tp, fp in zip(tp_arr, fp_arr)])
+        macro_recall = np.mean([safe_div(tp, tp + fn) for tp, fn in zip(tp_arr, fn_arr)])
+        macro_f1 = np.mean([
+            safe_div(2 * safe_div(tp, tp + fp) * safe_div(tp, tp + fn),
+                     safe_div(tp, tp + fp) + safe_div(tp, tp + fn))
+            for tp, fp, fn in zip(tp_arr, fp_arr, fn_arr)
+        ])
+        macro_tp_all = np.mean([safe_div(tp, s) for tp, s in zip(tp_arr, sent_arr)])
+        macro_fn_all = np.mean([safe_div(fn, s) for fn, s in zip(fn_arr, sent_arr)])
+        macro_fp_all = np.mean([safe_div(fp, s) for fp, s in zip(fp_arr, sent_arr)])
+        macro_tn_all = np.mean([safe_div(tn, s) for tn, s in zip(tn_arr, sent_arr)])
+        macro_decision_cov = np.mean([safe_div(d, s) for d, s in zip(decision_arr, sent_arr)])
+
+        print(
+            "[DEBUG][Confusion][Macro-Dec] "
+            f"TP%:{macro_tp_dec:.4f}, FN%:{macro_fn_dec:.4f}, FP%:{macro_fp_dec:.4f}, "
+            f"TN%:{macro_tn_dec:.4f}, Precision:{macro_precision:.4f}, Recall:{macro_recall:.4f}, F1:{macro_f1:.4f}"
+        )
+        print(
+            "[DEBUG][Confusion][Macro-All] "
+            f"TP%:{macro_tp_all:.4f}, FN%:{macro_fn_all:.4f}, FP%:{macro_fp_all:.4f}, "
+            f"TN%:{macro_tn_all:.4f}, Precision:{macro_precision:.4f}, Recall:{macro_recall:.4f}, "
+            f"F1:{macro_f1:.4f}, DecisionCoverage:{macro_decision_cov:.4f}"
         )
 
         return reward_tensor


### PR DESCRIPTION
## Summary
- track per-sentence TP/FP/TN/FN counts during reward calculation
- report micro and macro confusion metrics, precision/recall/F1 and decision coverage
- align sentence counting with spaCy sentence segmentation used in reward logic
- compute step-level reward stats from aggregated confusion counts to avoid redundant tensor scans

## Testing
- `python -m py_compile verl/trainer/main_ppo_sent_rind.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1fbf172cc833199392521614f0d3c