### PR TITLE
feat: add sentence-level confusion metrics

### DIFF
--- a/verl/trainer/main_ppo_sent_rind.py
+++ b/verl/trainer/main_ppo_sent_rind.py
@@ -19,8 +19,9 @@ from verl import DataProto
 import torch
 from verl.utils.reward_score import qa_em, qa_em_format
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
-import re
 import numpy as np
+import spacy
+from verl.utils.reward_score.rind_reward import TAG_BOUNDARY_RE, CLOSE_TAG_RE, LEADING_CLOSE_RE
 
 
 def _select_rm_score_fn(data_source):
@@ -42,6 +43,46 @@ class RewardManager():
         self.final_format_score = final_format_score
         self.retrieval_score = retrieval_score
         self.lambda_episode = lambda_episode
+        self.nlp = spacy.load("en_core_web_sm", disable=["ner"])
+
+    def _count_sentences(self, text: str) -> int:
+        doc = self.nlp(text)
+        raw_sents = [span.text for span in doc.sents if span.text.strip()]
+        sentences = []
+        for sent in raw_sents:
+            parts = []
+            cur = 0
+            has_match = False
+            for m in TAG_BOUNDARY_RE.finditer(sent):
+                has_match = True
+                if m.start() > cur:
+                    parts.append(sent[cur:m.start()])
+                parts.append(m.group(0))
+                cur = m.end()
+            if cur < len(sent):
+                parts.append(sent[cur:])
+            if not has_match:
+                m = LEADING_CLOSE_RE.match(sent)
+                if m:
+                    close_part = sent[:m.end()]
+                    if sentences:
+                        sentences[-1] += close_part
+                    else:
+                        sentences.append(close_part)
+                    if m.end() < len(sent):
+                        sentences.append(sent[m.end():])
+                    continue
+            for seg in parts:
+                if not seg.strip():
+                    continue
+                if CLOSE_TAG_RE.fullmatch(seg):
+                    if sentences:
+                        sentences[-1] += seg
+                    else:
+                        sentences.append(seg)
+                else:
+                    sentences.append(seg)
+        return len(sentences)
 
     def __call__(self, data: DataProto):
         """We will expand this function gradually based on the available datasets"""
@@ -54,6 +95,18 @@ class RewardManager():
 
         already_print_data_sources = {}
         all_scores = []
+
+        # containers for confusion matrix statistics
+        tp_list, fp_list, tn_list, fn_list = [], [], [], []
+        decision_counts, sentence_counts = [], []
+
+        # accumulators for step statistics and sentence-level sign rates
+        S_ep = 0.0
+        SS_ep = 0.0
+        Cross = 0.0
+        pos_sent_dec_sum = 0
+        neg_sent_dec_sum = 0
+        decision_counts_after = []
 
         for i in range(len(data)):
             data_item = data[i]
@@ -81,17 +134,41 @@ class RewardManager():
             sequences = torch.cat((valid_prompt_ids, response_ids[response_positions]))
             sequences_str = self.tokenizer.decode(sequences)
 
+            # decode response only for sentence counting
+            response_str = self.tokenizer.decode(response_ids[response_positions])
+            total_sents = self._count_sentences(response_str)
+
             rewards = data_item.non_tensor_batch.get('sentence_rewards', [])
+            tp = fp = tn = fn = 0
             for pos, val in rewards:
                 if pos < valid_response_length:
                     reward_pos = int(response_positions[pos].item())
                     reward_tensor[i, reward_pos] = val
+                    if val == 2:
+                        tp += 1
+                    elif val == -2:
+                        fn += 1
+                    elif val == -1:
+                        fp += 1
+                    elif val == 1:
+                        tn += 1
                     #end_token_id = response_ids[reward_pos].item()
                     #end_token_str = self.tokenizer.decode([end_token_id])
                     #start_slice = max(0, pos - 20)
                     #snippet_ids = response_ids[response_positions[start_slice:pos + 1]].tolist()
                     #snippet_str = self.tokenizer.decode(snippet_ids)
                     #print( f"句末token: {end_token_str}, 句末token索引: {reward_pos}, 句子片段: {snippet_str}，句末奖励：{val}" )
+
+            tp_list.append(tp)
+            fp_list.append(fp)
+            tn_list.append(tn)
+            fn_list.append(fn)
+            decision_counts.append(tp + fp + tn + fn)
+            sentence_counts.append(total_sents)
+
+            pos_sent = tp + tn
+            neg_sent = fp + fn
+            dec_cnt = pos_sent + neg_sent
 
             data_source = data_item.non_tensor_batch['data_source']
             compute_score_fn = _select_rm_score_fn(data_source)
@@ -106,7 +183,35 @@ class RewardManager():
             )
             if valid_response_length > 0:
                 last_pos = int(response_positions[valid_response_length - 1].item())
-                reward_tensor[i, last_pos] = reward_tensor[i, last_pos] + self.lambda_episode * score
+                # read the original step reward before applying episode bonus
+                prev_reward = float(reward_tensor[i, last_pos].item())
+                s = float(self.lambda_episode * score)
+
+                # accumulate episode-level statistics without mutating reward_tensor
+                S_ep += s
+                SS_ep += s * s
+                Cross += 2.0 * prev_reward * s
+
+                # remove the old sign contribution of the last sentence
+                if prev_reward > 0:
+                    pos_sent -= 1
+                elif prev_reward < 0:
+                    neg_sent -= 1
+
+                vs = prev_reward + s
+                eps = 1e-12
+                if vs > eps:
+                    pos_sent += 1
+                elif vs < -eps:
+                    neg_sent += 1
+
+                if abs(prev_reward) <= eps and abs(vs) > eps:
+                    dec_cnt += 1
+                elif abs(prev_reward) > eps and abs(vs) <= eps:
+                    dec_cnt = max(0, dec_cnt - 1)
+
+                # write the combined reward exactly once
+                reward_tensor[i, last_pos] = vs
                 all_scores.append(score)
 
             if data_source not in already_print_data_sources:
@@ -114,6 +219,10 @@ class RewardManager():
             if already_print_data_sources[data_source] < self.num_examine:
                 already_print_data_sources[data_source] += 1
                 print(sequences_str)
+
+            pos_sent_dec_sum += pos_sent
+            neg_sent_dec_sum += neg_sent
+            decision_counts_after.append(dec_cnt)
 
         if all_scores:
             print(
@@ -128,38 +237,75 @@ class RewardManager():
         else:
             resp_mask = data.batch['attention_mask'][:, prompt_len:]
         resp_mask = resp_mask.to(reward_tensor.device)
-        valid_rewards = reward_tensor[resp_mask.bool()]
+        resp_mask_bool = resp_mask.bool()
+        N_total = int(resp_mask.sum().item())
 
-        if valid_rewards.numel() > 0:
-            vr = valid_rewards.cpu().numpy()
-            step_mean = vr.mean()
-            step_std = vr.std()
-            step_min = vr.min()
-            step_max = vr.max()
-            pos_rate = (vr > 0).mean()
-            neg_rate = (vr < 0).mean()
+        tp = int(np.sum(tp_list))
+        fp = int(np.sum(fp_list))
+        tn = int(np.sum(tn_list))
+        fn = int(np.sum(fn_list))
+
+        S_dec = 2 * tp + tn - fp - 2 * fn
+        SS_dec = 4 * (tp + fn) + (tn + fp)
+
+        S_total = S_dec + S_ep
+        SS_total = SS_dec + SS_ep + Cross
+
+        if N_total > 0:
+            step_mean = S_total / N_total
+            step_var = max(0.0, SS_total / N_total - step_mean * step_mean)
+            step_std = float(np.sqrt(step_var))
         else:
-            step_mean = step_std = step_min = step_max = pos_rate = neg_rate = 0.0
+            step_mean = step_std = 0.0
+
+        valid_vals = reward_tensor[resp_mask_bool]
+        if valid_vals.numel() > 0:
+            pos_rate_token = float((valid_vals > 0).float().mean().item())
+            neg_rate_token = float((valid_vals < 0).float().mean().item())
+            step_min = float(valid_vals.min().item())
+            step_max = float(valid_vals.max().item())
+        else:
+            pos_rate_token = neg_rate_token = 0.0
+            step_min = step_max = 0.0
 
         print(
             f"[DEBUG][Step] step_reward/mean: {step_mean:.4f}, /std: {step_std:.4f}, /min: {step_min:.4f}, "
-            f"/max: {step_max:.4f}, /pos_rate: {pos_rate:.4f}, /neg_rate: {neg_rate:.4f}"
+            f"/max: {step_max:.4f}, /pos_rate(token): {pos_rate_token:.4f}, /neg_rate(token): {neg_rate_token:.4f}"
+        )
+
+        # sentence-level positive/negative rates with two denominators
+        m_decision_after = int(np.sum(decision_counts_after))
+        m_sent_all = int(np.sum(sentence_counts))
+
+        def sdiv(a, b):
+            return float(a) / float(b) if b else 0.0
+
+        print(
+            "[DEBUG][Sentence][Decision] "
+            f"pos_rate: {sdiv(pos_sent_dec_sum, m_decision_after):.4f}, "
+            f"neg_rate: {sdiv(neg_sent_dec_sum, m_decision_after):.4f}, "
+            f"DecisionCoverage: {sdiv(m_decision_after, m_sent_all):.4f}"
+        )
+        print(
+            "[DEBUG][Sentence][All] "
+            f"pos_rate: {sdiv(pos_sent_dec_sum, m_sent_all):.4f}, "
+            f"neg_rate: {sdiv(neg_sent_dec_sum, m_sent_all):.4f}"
         )
 
         # Compute per-sample aggregated rewards within batch
-        sample_mask = resp_mask.bool()
-        sample_returns = (reward_tensor * sample_mask).sum(dim=1)
-        nonzero_steps = (reward_tensor * sample_mask != 0).sum(dim=1)
-        sample_lengths = sample_mask.sum(dim=1)
+        sample_returns = (reward_tensor * resp_mask_bool).sum(dim=1)
 
-        sr = sample_returns.cpu().numpy()
+        dec_arr_after = np.asarray(decision_counts_after, dtype=np.float64)
+        sent_arr_full = np.asarray(sentence_counts, dtype=np.float64)
+
+        sr = sample_returns.detach().cpu().numpy()
         if sr.size > 0:
-            return_mean = sr.mean()
-            return_std = sr.std()
-            return_min = sr.min()
-            return_max = sr.max()
-            nz_steps_mean = nonzero_steps.float().mean().item()
-            len_mean = sample_lengths.float().mean().item()
+            return_mean = float(sr.mean())
+            return_std = float(sr.std())
+            return_min = float(sr.min())
+            return_max = float(sr.max())
+            nz_steps_mean = float(dec_arr_after.mean()) if dec_arr_after.size else 0.0
+            len_mean = float(sent_arr_full.mean()) if sent_arr_full.size else 0.0
         else:
             return_mean = return_std = return_min = return_max = 0.0
             nz_steps_mean = len_mean = 0.0
@@ -167,6 +313,84 @@ class RewardManager():
         print(
             f"[DEBUG][Step] sample/return_mean: {return_mean:.4f}, /std: {return_std:.4f}, /min: {return_min:.4f}, "
             f"/max: {return_max:.4f}, /nonzero_steps_mean: {nz_steps_mean:.4f}, /len_mean: {len_mean:.4f}"
+        )
+
+        # === Confusion matrix based metrics ===
+        tp_arr = np.array(tp_list)
+        fp_arr = np.array(fp_list)
+        tn_arr = np.array(tn_list)
+        fn_arr = np.array(fn_list)
+        decision_arr = np.array(decision_counts)
+        sent_arr = np.array(sentence_counts)
+
+        def safe_div(n, d):
+            return float(n) / float(d) if d else 0.0
+
+        # micro aggregation
+        m_tp, m_fp, m_tn, m_fn = tp, fp, tn, fn
+        m_decision = decision_arr.sum()
+        m_sent = sent_arr.sum()
+        micro_precision = safe_div(m_tp, m_tp + m_fp)
+        micro_recall = safe_div(m_tp, m_tp + m_fn)
+        micro_f1 = safe_div(2 * micro_precision * micro_recall, micro_precision + micro_recall)
+
+        print(
+            "[DEBUG][Confusion][Micro-Dec] "
+            f"TP%:{safe_div(m_tp, m_decision):.4f}, FN%:{safe_div(m_fn, m_decision):.4f}, "
+            f"FP%:{safe_div(m_fp, m_decision):.4f}, TN%:{safe_div(m_tn, m_decision):.4f}, "
+            f"Precision:{micro_precision:.4f}, Recall:{micro_recall:.4f}, F1:{micro_f1:.4f}"
+        )
+        print(
+            "[DEBUG][Confusion][Micro-All] "
+            f"TP%:{safe_div(m_tp, m_sent):.4f}, FN%:{safe_div(m_fn, m_sent):.4f}, "
+            f"FP%:{safe_div(m_fp, m_sent):.4f}, TN%:{safe_div(m_tn, m_sent):.4f}, "
+            f"Precision:{micro_precision:.4f}, Recall:{micro_recall:.4f}, F1:{micro_f1:.4f}, "
+            f"DecisionCoverage:{safe_div(m_decision, m_sent):.4f}"
+        )
+
+        # macro aggregation with per-metric denominator masks
+        def mean_or0(x):
+            x = np.asarray(x)
+            return float(x.mean()) if x.size else 0.0
+
+        mask_dec = decision_arr > 0
+        macro_tp_dec = mean_or0(tp_arr[mask_dec] / decision_arr[mask_dec])
+        macro_fn_dec = mean_or0(fn_arr[mask_dec] / decision_arr[mask_dec])
+        macro_fp_dec = mean_or0(fp_arr[mask_dec] / decision_arr[mask_dec])
+        macro_tn_dec = mean_or0(tn_arr[mask_dec] / decision_arr[mask_dec])
+
+        mask_p = (tp_arr + fp_arr) > 0
+        mask_r = (tp_arr + fn_arr) > 0
+
+        prec_i = (tp_arr[mask_p] / (tp_arr[mask_p] + fp_arr[mask_p])).astype(float)
+        rec_i = (tp_arr[mask_r] / (tp_arr[mask_r] + fn_arr[mask_r])).astype(float)
+
+        idx_f1 = (tp_arr + fp_arr > 0) & (tp_arr + fn_arr > 0)
+        p_f1 = tp_arr[idx_f1] / (tp_arr[idx_f1] + fp_arr[idx_f1])
+        r_f1 = tp_arr[idx_f1] / (tp_arr[idx_f1] + fn_arr[idx_f1])
+        f1_i = np.where((p_f1 + r_f1) > 0, 2 * p_f1 * r_f1 / (p_f1 + r_f1), 0.0).astype(float)
+
+        macro_precision = mean_or0(prec_i)
+        macro_recall = mean_or0(rec_i)
+        macro_f1 = mean_or0(f1_i)
+
+        mask_all = sent_arr > 0
+        macro_tp_all = mean_or0(tp_arr[mask_all] / sent_arr[mask_all])
+        macro_fn_all = mean_or0(fn_arr[mask_all] / sent_arr[mask_all])
+        macro_fp_all = mean_or0(fp_arr[mask_all] / sent_arr[mask_all])
+        macro_tn_all = mean_or0(tn_arr[mask_all] / sent_arr[mask_all])
+        macro_decision_cov = mean_or0(decision_arr[mask_all] / sent_arr[mask_all])
+
+        print(
+            "[DEBUG][Confusion][Macro-Dec] "
+            f"TP%:{macro_tp_dec:.4f}, FN%:{macro_fn_dec:.4f}, FP%:{macro_fp_dec:.4f}, "
+            f"TN%:{macro_tn_dec:.4f}, Precision:{macro_precision:.4f}, Recall:{macro_recall:.4f}, F1:{macro_f1:.4f}"
+        )
+        print(
+            "[DEBUG][Confusion][Macro-All] "
+            f"TP%:{macro_tp_all:.4f}, FN%:{macro_fn_all:.4f}, FP%:{macro_fp_all:.4f}, "
+            f"TN%:{macro_tn_all:.4f}, Precision:{macro_precision:.4f}, Recall:{macro_recall:.4f}, "
+            f"F1:{macro_f1:.4f}, DecisionCoverage:{macro_decision_cov:.4f}"
         )
 
         return reward_tensor


### PR DESCRIPTION
## Summary
- capture last-step reward before applying episode bonus to avoid double counting and update token sign statistics safely
- consolidate sentence metrics into decision/all lines and drop redundant CPU scans for efficiency
- report micro and macro precision/recall/F1 with decision coverage based on confusion counts

## Testing
- `python -m py_compile verl/trainer/main_ppo_sent_rind.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1fbf172cc833199392521614f0d3c