### PR TITLE
Add None handling in reward normalization

### DIFF
--- a/verl/utils/reward_score/qa_em.py
+++ b/verl/utils/reward_score/qa_em.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 

--- a/verl/utils/reward_score/qa_em_format.py
+++ b/verl/utils/reward_score/qa_em_format.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 

--- a/verl/utils/reward_score/qa_em_format_retrieval.py
+++ b/verl/utils/reward_score/qa_em_format_retrieval.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 

--- a/verl/utils/reward_score/qa_semantic_score_format_retrieval.py
+++ b/verl/utils/reward_score/qa_semantic_score_format_retrieval.py
@@ -22,6 +22,8 @@ from collections import Counter
 LLM_API_URL = "http://127.0.0.1:8001/v1/completions"  # MODIFIED
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 

--- a/verl/utils/reward_score/qa_sfllm_semantic_score_format_retrieval.py
+++ b/verl/utils/reward_score/qa_sfllm_semantic_score_format_retrieval.py
@@ -25,6 +25,8 @@ LLM_API_URL = "http://llm-model-hub-apis.sf-express.com"  # http://llm-model-hub
 API_KEY = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJhcGkyX2VkMjM2YWI4LTJhZDMtNDE2Yy05ZTMyLWU4OWJjZGVjYjYyNyIsImVudiI6InByZCIsImp0aSI6MjA4NDIsInByb2plY3RfaWQiOjQ2Niwic3lzdGVtS2V5IjoiYTVmMDI4NjItMmRjYS00YzJmLTk3MDktZjdmMThhYjMzMzNlIn0.tpkfC0aaxiiVklYT6tXq-OxbKxnyN4y-IW8NtSdCYAU"  # === MODIFIED: 填上申请到的 token
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 


### PR DESCRIPTION
## Summary
- guard normalize_answer helpers in reward score modules so missing answers default to empty strings and no longer crash EM or F1 checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dccd3bca588331942e7bc782d03fe5