### PR TITLE
Handle None predictions in reward scoring guards

### DIFF
--- a/verl/utils/reward_score/qa_em.py
+++ b/verl/utils/reward_score/qa_em.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -28,12 +30,16 @@ def normalize_answer(s):
         return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
+        if text is None:
+            return ""
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
 def em_check(prediction, golden_answers):
+    if prediction is None:
+        return 0
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)

--- a/verl/utils/reward_score/qa_em_format.py
+++ b/verl/utils/reward_score/qa_em_format.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -28,12 +30,16 @@ def normalize_answer(s):
         return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
+        if text is None:
+            return ""
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
 def em_check(prediction, golden_answers):
+    if prediction is None:
+        return 0
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)

--- a/verl/utils/reward_score/qa_em_format_retrieval.py
+++ b/verl/utils/reward_score/qa_em_format_retrieval.py
@@ -17,6 +17,8 @@ import string
 import random
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -28,12 +30,16 @@ def normalize_answer(s):
         return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
+        if text is None:
+            return ""
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
 def em_check(prediction, golden_answers):
+    if prediction is None:
+        return 0
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)

--- a/verl/utils/reward_score/qa_semantic_score_format_retrieval.py
+++ b/verl/utils/reward_score/qa_semantic_score_format_retrieval.py
@@ -22,6 +22,8 @@ from collections import Counter
 LLM_API_URL = "http://127.0.0.1:8001/v1/completions"  # MODIFIED
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -33,12 +35,16 @@ def normalize_answer(s):
         return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
+        if text is None:
+            return ""
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
 def em_check(prediction, golden_answers):
+    if prediction is None:
+        return 0
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)

--- a/verl/utils/reward_score/qa_sfllm_semantic_score_format_retrieval.py
+++ b/verl/utils/reward_score/qa_sfllm_semantic_score_format_retrieval.py
@@ -25,6 +25,8 @@ LLM_API_URL = "http://llm-model-hub-apis.sf-express.com"  # http://llm-model-hub
 API_KEY = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJhcGkyX2VkMjM2YWI4LTJhZDMtNDE2Yy05ZTMyLWU4OWJjZGVjYjYyNyIsImVudiI6InByZCIsImp0aSI6MjA4NDIsInByb2plY3RfaWQiOjQ2Niwic3lzdGVtS2V5IjoiYTVmMDI4NjItMmRjYS00YzJmLTk3MDktZjdmMThhYjMzMzNlIn0.tpkfC0aaxiiVklYT6tXq-OxbKxnyN4y-IW8NtSdCYAU"  # === MODIFIED: 填上申请到的 token
 
 def normalize_answer(s):
+    if s is None:
+        return ""
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -36,12 +38,16 @@ def normalize_answer(s):
         return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
+        if text is None:
+            return ""
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
 def em_check(prediction, golden_answers):
+    if prediction is None:
+        return 0
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)
@@ -416,7 +422,8 @@ def compute_score_em(solution_str, ground_truth, model_path, structure_format_sc
     #final_score = max(0, lambda_task * final_em_format_score - lambda_search_num * n_search - lambda_repeat_search_num * n_repeat)
     
     if do_print:
-        print(f"EM Score: {em_check(answer, ground_truth['target'])}")
+        em = em_check(answer, ground_truth['target']) if answer else 0
+        print(f"EM Score: {em}")
         print(f"LLM Semantic Score: {llm_score}")
         print(f"F-1 Score: {f1_score}")
         print(f"Format Valid: {is_valid_format}")


### PR DESCRIPTION
## Summary
- short-circuit EM logging when answers are missing to avoid calling normalize on None
- return early from EM helpers when predictions are None and guard lower() helpers across reward scoring modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dccd3bca588331942e7bc782d03fe5